### PR TITLE
Enable npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release-loop-audit.yml
+++ b/.github/workflows/release-loop-audit.yml
@@ -22,6 +22,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: tools/loop-audit/package-lock.json
 
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
       - name: Install, build, test
         working-directory: tools/loop-audit
         run: |
@@ -29,8 +32,6 @@ jobs:
           npm run build
           npm test
 
-      - name: Publish to npm
+      - name: Publish to npm (trusted publishing — no NPM_TOKEN)
         working-directory: tools/loop-audit
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance

--- a/.github/workflows/release-loop-init.yml
+++ b/.github/workflows/release-loop-init.yml
@@ -20,11 +20,12 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
       - name: Test, build & publish
         working-directory: tools/loop-init
         run: |
           npm ci
           npm test
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --access public --provenance

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,11 +7,18 @@ This repo ships two public npm packages from `tools/`:
 | `@cobusgreyling/loop-audit` | `tools/loop-audit` | `loop-audit-v*` |
 | `@cobusgreyling/loop-init` | `tools/loop-init` | `loop-init-v*` |
 
-## One-time setup
+## One-time setup (trusted publishing — recommended)
 
-1. Create an npm org/user scope `@cobusgreyling` on [npmjs.com](https://www.npmjs.com/).
-2. Generate an npm **Automation** or **Publish** token.
-3. Add it to the repo as **`NPM_TOKEN`** (Settings → Secrets → Actions).
+Link npm to GitHub, then for **each package** on [npmjs.com](https://www.npmjs.com/) → package **Settings** → **Trusted Publisher** → **GitHub Actions**:
+
+| Package | Repository | Workflow filename |
+|---------|--------------|-------------------|
+| `@cobusgreyling/loop-audit` | `cobusgreyling/loop-engineering` | `release-loop-audit.yml` |
+| `@cobusgreyling/loop-init` | `cobusgreyling/loop-engineering` | `release-loop-init.yml` |
+
+Names must match **exactly** (case-sensitive). No `NPM_TOKEN` secret is required when trusted publishing is configured.
+
+**Legacy fallback:** add an npm Automation token as repo secret `NPM_TOKEN` and restore `NODE_AUTH_TOKEN` in the publish steps.
 
 ## Version bump
 


### PR DESCRIPTION
Removes NPM_TOKEN dependency when npm Trusted Publisher is configured per package.