### PR TITLE
Restore NPM_TOKEN for npm publish

### DIFF
--- a/.github/workflows/release-loop-audit.yml
+++ b/.github/workflows/release-loop-audit.yml
@@ -32,6 +32,8 @@ jobs:
           npm run build
           npm test
 
-      - name: Publish to npm (trusted publishing — no NPM_TOKEN)
+      - name: Publish to npm
         working-directory: tools/loop-audit
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-loop-init.yml
+++ b/.github/workflows/release-loop-init.yml
@@ -29,3 +29,5 @@ jobs:
           npm ci
           npm test
           npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Uses the configured NPM_TOKEN secret alongside provenance.