### PR TITLE
fix(ci): daily triage PR step — gh pr create lacks --json flag

### DIFF
--- a/.github/workflows/daily-triage.yml
+++ b/.github/workflows/daily-triage.yml
@@ -105,15 +105,15 @@ jobs:
             echo "PR #$EXISTING already open"
             PR_NUMBER="$EXISTING"
           else
-            PR_NUMBER=$(gh pr create \
+            gh pr create \
               --base main \
               --head "$BRANCH" \
               --title "chore(loop): daily triage STATE.md $(date -u +%Y-%m-%d)" \
               --body "Automated daily triage update from \`daily-triage.yml\`.
 
           - Loop readiness: **${{ steps.audit.outputs.score }}** (${{ steps.audit.outputs.level }})
-          - Merges automatically when \`validate\` and \`audit\` pass." \
-              --json number -q '.number')
+          - Merges automatically when \`validate\` and \`audit\` pass."
+            PR_NUMBER=$(gh pr view "$BRANCH" --json number -q '.number')
           fi
 
           gh pr merge "$PR_NUMBER" --auto --squash --delete-branch


### PR DESCRIPTION
Fixes failed run https://github.com/cobusgreyling/loop-engineering/actions/runs/27273027765

The `Open PR for STATE.md if changed` step failed with:
```
unknown flag: --json
Usage: gh pr create [flags]
```

`gh pr create` does not support `--json` on GitHub-hosted runners. Create the PR first, then read the number via `gh pr view`.