### PR TITLE
chore(discoverability): tighten repo About, add topics, improve README + npm metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 
 **Loop engineering is replacing yourself as the person who prompts the agent. You design the system that does it instead.**
 
+For developers using Grok, Claude Code, Codex, Cursor, and other AI coding agents.
+
 A loop is a recursive goal: you define a purpose and the AI iterates (often with sub-agents, verification, and external state) until the goal is complete or the loop decides to hand off to you.
 
 
@@ -33,9 +35,11 @@ A loop is a recursive goal: you define a purpose and the AI iterates (often with
 </p>
 
 <p align="center">
-  <strong><a href="https://cobusgreyling.github.io/loop-engineering/">→ cobusgreyling.github.io/loop-engineering</a></strong>
+  <strong><a href="https://cobusgreyling.github.io/loop-engineering/">→ Interactive showcase + pattern picker</a></strong>
   <br>
-  <strong><a href="https://cobusgreyling.substack.com/p/loop-engineering">→ Read the Loop Engineering essay on Substack</a></strong>
+  <strong><a href="https://cobusgreyling.substack.com/p/loop-engineering">→ Loop Engineering essay (Substack)</a></strong>
+  <br>
+  <a href="https://addyosmani.com/blog/loop-engineering/">Canonical essay by Addy Osmani</a>
 </p>
 
 ## Contents

--- a/tools/loop-audit/package.json
+++ b/tools/loop-audit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cobusgreyling/loop-audit",
   "version": "1.4.0",
-  "description": "Loop Readiness Score — audit a project for loop engineering readiness (L0-L3). Dynamic activity detection + --suggest. npx @cobusgreyling/loop-audit . --suggest",
+  "description": "Loop engineering readiness auditor. Compute Loop Readiness Score (L0-L3), detect activity, and get actionable suggestions. npx @cobusgreyling/loop-audit . --suggest",
   "type": "module",
   "bin": {
     "loop-audit": "./dist/cli.js"

--- a/tools/loop-cost/package.json
+++ b/tools/loop-cost/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cobusgreyling/loop-cost",
   "version": "1.0.1",
-  "description": "Estimate daily token spend for loop engineering patterns by cadence and readiness level.",
+  "description": "Estimate token budgets and daily costs for loop engineering patterns. By cadence, readiness level (L1/L2/L3), and coding agent tool.",
   "type": "module",
   "bin": {
     "loop-cost": "dist/cli.js"
@@ -24,8 +24,13 @@
   "keywords": [
     "loop-engineering",
     "ai-agents",
+    "coding-agents",
     "token-budget",
-    "cost-estimate"
+    "cost-estimate",
+    "claude-code",
+    "grok",
+    "budget",
+    "devtools"
   ],
   "author": "Cobus Greyling",
   "license": "MIT",

--- a/tools/loop-init/package.json
+++ b/tools/loop-init/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cobusgreyling/loop-init",
   "version": "1.2.0",
-  "description": "Scaffold loop engineering starters into your project by pattern and tool.",
+  "description": "Scaffold loop engineering patterns and starters into any project. Supports Grok, Claude Code, Codex and more. npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok",
   "type": "module",
   "bin": {
     "loop-init": "./dist/cli.js"
@@ -25,8 +25,14 @@
   "keywords": [
     "loop-engineering",
     "ai-agents",
+    "coding-agents",
     "scaffold",
-    "starter"
+    "starter",
+    "claude-code",
+    "grok",
+    "codex",
+    "github-actions",
+    "patterns"
   ],
   "author": "Cobus Greyling",
   "license": "MIT",


### PR DESCRIPTION
Minor discoverability improvements:

- GitHub repo About/description: Tighter, tool-focused text mentioning loop-audit / loop-init / loop-cost + Addy Osmani / Boris Cherny inspiration.
- Topics: Added coding-agents, anthropic, claude, devtools (on top of existing strong set).
- README: Added audience targeting line ("For developers using Grok, Claude Code, Codex, Cursor...") right after the definition. Improved hero links to highlight the interactive showcase + direct link to Addy Osmani's canonical essay.
- npm packages: Enriched descriptions and keywords for @cobusgreyling/loop-audit, loop-init, and loop-cost (better npx/npm search visibility).

These are small, high-leverage metadata + copy changes only. No behavior or code changes.

(Originally prepared as a direct main commit; converted to PR to satisfy branch protection rules.)