### PR TITLE
chore: bump npm package versions for metadata discoverability updates

### DIFF
--- a/tools/loop-audit/CHANGELOG.md
+++ b/tools/loop-audit/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@cobusgreyling/loop-audit` are documented here.
 
+## [1.4.1] - 2026-06-13
+
+### Changed
+- Updated package description and keywords for better discoverability on npm / npx (emphasizes "loop engineering", coding agents, and concrete usage examples).
+
 ## [1.3.0] - 2026-06-09
 
 ### Added

--- a/tools/loop-audit/package.json
+++ b/tools/loop-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobusgreyling/loop-audit",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Loop engineering readiness auditor. Compute Loop Readiness Score (L0-L3), detect activity, and get actionable suggestions. npx @cobusgreyling/loop-audit . --suggest",
   "type": "module",
   "bin": {

--- a/tools/loop-cost/package.json
+++ b/tools/loop-cost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobusgreyling/loop-cost",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Estimate token budgets and daily costs for loop engineering patterns. By cadence, readiness level (L1/L2/L3), and coding agent tool.",
   "type": "module",
   "bin": {

--- a/tools/loop-init/package.json
+++ b/tools/loop-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobusgreyling/loop-init",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Scaffold loop engineering patterns and starters into any project. Supports Grok, Claude Code, Codex and more. npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps the three published packages to ship the improved descriptions and keywords from the recent discoverability work:

- `@cobusgreyling/loop-audit` 1.4.0 → **1.4.1**
- `@cobusgreyling/loop-init` 1.2.0 → **1.2.1**
- `@cobusgreyling/loop-cost` 1.0.1 → **1.0.2**

### Changes
- Richer package descriptions (now mention "loop engineering", specific usage, and npx examples)
- Expanded keywords for better search / npx discoverability (coding-agents, claude-code, grok, etc.)
- Added changelog entry for loop-audit

This is a metadata-only release (no behavior changes).

After this PR merges, the release tags will be pushed to trigger the GitHub Actions publish workflows (which use trusted publishing).

See: docs/RELEASE.md