### PR TITLE
fix: goal-audit npm publish without provenance

### DIFF
--- a/.github/workflows/publish-goal-audit-bootstrap.yml
+++ b/.github/workflows/publish-goal-audit-bootstrap.yml
@@ -36,6 +36,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: tools/goal-audit
-        run: npm publish --access public --provenance
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
First publish of @cobusgreyling/goal-audit failed with E404 when using --provenance. Publish with NPM_TOKEN only.