### PR TITLE
fix(goal-audit): fixture skills path for CI + v1.0.2

### DIFF
--- a/tools/goal-audit/package.json
+++ b/tools/goal-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobusgreyling/goal-audit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Goal engineering readiness auditor for Grok Build /goal. Compute Goal Readiness Score (G0-G3). npx @cobusgreyling/goal-audit . --suggest",
   "type": "module",
   "bin": {

--- a/tools/goal-audit/test/fixtures/good-goal-project/skills/goal-verifier/SKILL.md
+++ b/tools/goal-audit/test/fixtures/good-goal-project/skills/goal-verifier/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: goal-verifier
+description: Verify goal completion.
+---
+# Verifier


### PR DESCRIPTION
loop-engineering gitignore blocks .grok/ in test fixtures.