### PR TITLE
Fix dead triage regex, CLI input validation, and self-grading dogfood loop

### DIFF
--- a/.github/workflows/daily-triage.yml
+++ b/.github/workflows/daily-triage.yml
@@ -121,13 +121,28 @@ jobs:
           node scripts/append-run-log.mjs "$ENTRY"
           echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
 
+      # These run the SAME gates a PR-triggered workflow would. Their outcomes
+      # (not a hardcoded value) drive the commit statuses posted below, so the
+      # loop cannot mark its own change green unless the real gates passed.
+      # continue-on-error lets us record a failing outcome and post an honest
+      # "failure" status instead of aborting before the status is set.
       - name: Run validate gates (for PR status)
         id: validate_gates
+        continue-on-error: true
         run: bash scripts/ci-validate-gates.sh
 
       - name: Run audit gates (for PR status)
         id: audit_gates
+        continue-on-error: true
         run: bash scripts/ci-audit-gates.sh
+
+      - name: Fail the run if either gate failed
+        if: steps.validate_gates.outcome == 'failure' || steps.audit_gates.outcome == 'failure'
+        run: |
+          echo "validate gates: ${{ steps.validate_gates.outcome }}"
+          echo "audit gates:    ${{ steps.audit_gates.outcome }}"
+          echo "One or more dogfood gates failed — not opening/merging an automated PR."
+          exit 1
 
       - name: Open PR for STATE.md + loop-run-log if changed
         id: pr
@@ -186,16 +201,27 @@ jobs:
               core.setFailed('Missing head_sha for commit statuses');
               return;
             }
+            // Map each gate's real step outcome to the commit status it backs.
+            // 'success' is only posted when the corresponding gate actually passed.
+            const toState = (outcome) => (outcome === 'success' ? 'success' : 'failure');
             const checks = [
-              { context: 'validate', description: 'Pattern/registry gates (daily-triage inline)' },
-              { context: 'audit', description: 'Loop readiness gates (daily-triage inline)' },
+              {
+                context: 'validate',
+                description: 'Pattern/registry gates (daily-triage inline)',
+                state: toState('${{ steps.validate_gates.outcome }}'),
+              },
+              {
+                context: 'audit',
+                description: 'Loop readiness gates (daily-triage inline)',
+                state: toState('${{ steps.audit_gates.outcome }}'),
+              },
             ];
             for (const check of checks) {
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 sha,
-                state: 'success',
+                state: check.state,
                 context: check.context,
                 description: check.description,
                 target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,

--- a/tools/loop-audit/dist/auditor.js
+++ b/tools/loop-audit/dist/auditor.js
@@ -23,6 +23,43 @@ const LOOP_SKILL_NAMES = [
     'draft-release-notes',
     'issue-triage',
 ];
+/**
+ * Score contribution for each readiness signal, out of 100.
+ *
+ * These weights are intentionally centralized (rather than inlined in
+ * `computeScore`) so the rubric is auditable in one place and the
+ * level thresholds below stay meaningful when weights change.
+ * `base` is the floor every project starts from. The remaining weights
+ * sum (with `base`) to 100 when every signal is present.
+ */
+const SCORE_WEIGHTS = {
+    base: 10,
+    stateFile: 18,
+    triage: 14,
+    loopConfig: 9,
+    agentsMd: 9,
+    skillsTwoPlus: 14,
+    skillsOne: 7,
+    verifier: 14,
+    safetyLoopMd: 4,
+    safetyDoc: 4,
+    github: 6,
+    githubWorkflows: 4,
+    mcp: 3,
+    worktree: 3,
+    registry: 2,
+    budgetDoc: 3,
+    runLog: 3,
+    loopMdBudget: 2,
+    budgetSkill: 2,
+    loopActivity: 6,
+};
+/** Minimum total score required to reach each readiness level (gated by additional signal requirements in `computeScore`). */
+const LEVEL_THRESHOLDS = {
+    L1: 38,
+    L2: 58,
+    L3: 78,
+};
 const SAFETY_FILES = ['safety.md', 'docs/safety.md', 'SECURITY.md'];
 const MCP_FILES = ['.mcp.json', 'mcp.json', '.mcp/config.json'];
 const WORKTREE_HINTS = ['worktree', 'worktrees', 'git worktree'];
@@ -122,7 +159,7 @@ async function detectLoopActivity(root) {
             timeout: 1500,
         });
         const lower = log.toLowerCase();
-        if (/state\.md|loop| t riage |changelog-drafter|post-merge|daily triage|audit/i.test(lower)) {
+        if (/state\.md|loop|triage|changelog-drafter|post-merge|daily triage|audit/i.test(lower)) {
             const firstMatch = log.trim().split('\n')[0] || '';
             evidence.push(`git:${firstMatch.slice(0, 60)}`);
         }
@@ -143,45 +180,46 @@ async function detectLoopActivity(root) {
     return { present: evidence.length > 0, evidence: Array.from(new Set(evidence)).slice(0, 4) };
 }
 export function computeScore(signals) {
-    let score = 10;
+    const w = SCORE_WEIGHTS;
+    let score = w.base;
     if (signals.stateFile.present)
-        score += 18;
+        score += w.stateFile;
     if (signals.triage.present)
-        score += 14;
+        score += w.triage;
     if (signals.loopConfig.present)
-        score += 9;
+        score += w.loopConfig;
     if (signals.agentsMd.present)
-        score += 9;
+        score += w.agentsMd;
     if (signals.skills.count >= 2)
-        score += 14;
+        score += w.skillsTwoPlus;
     else if (signals.skills.count === 1)
-        score += 7;
+        score += w.skillsOne;
     if (signals.verifier.present)
-        score += 14;
+        score += w.verifier;
     if (signals.safety.loopMdMentionsSafety)
-        score += 4;
+        score += w.safetyLoopMd;
     if (signals.safety.safetyDocPresent)
-        score += 4;
+        score += w.safetyDoc;
     if (signals.github.present)
-        score += 6;
+        score += w.github;
     if (signals.github.workflows)
-        score += 4;
+        score += w.githubWorkflows;
     if (signals.mcp.present)
-        score += 3;
+        score += w.mcp;
     if (signals.worktreeEvidence.present)
-        score += 3;
+        score += w.worktree;
     if (signals.registry.present)
-        score += 2;
+        score += w.registry;
     if (signals.cost.budgetDoc)
-        score += 3;
+        score += w.budgetDoc;
     if (signals.cost.runLog)
-        score += 3;
+        score += w.runLog;
     if (signals.cost.loopMdBudget)
-        score += 2;
+        score += w.loopMdBudget;
     if (signals.cost.budgetSkill)
-        score += 2;
+        score += w.budgetSkill;
     if (signals.loopActivity.present)
-        score += 6;
+        score += w.loopActivity;
     score = Math.min(100, Math.max(0, score));
     const costReady = signals.cost.budgetDoc &&
         signals.cost.runLog &&
@@ -189,11 +227,11 @@ export function computeScore(signals) {
     const hasRealActivity = signals.loopActivity.present;
     const l3Ready = costReady && hasRealActivity;
     let level = 'L0';
-    if (score >= 78 && signals.verifier.present && signals.stateFile.present && l3Ready)
+    if (score >= LEVEL_THRESHOLDS.L3 && signals.verifier.present && signals.stateFile.present && l3Ready)
         level = 'L3';
-    else if (score >= 58 && signals.triage.present)
+    else if (score >= LEVEL_THRESHOLDS.L2 && signals.triage.present)
         level = 'L2';
-    else if (score >= 38 && signals.stateFile.present)
+    else if (score >= LEVEL_THRESHOLDS.L1 && signals.stateFile.present)
         level = 'L1';
     else
         level = 'L0';
@@ -409,13 +447,13 @@ export async function auditProject(target) {
     const costReady = signals.cost.budgetDoc &&
         signals.cost.runLog &&
         signals.cost.loopMdBudget;
-    if (score >= 78 && signals.verifier.present && signals.stateFile.present && !costReady) {
+    if (score >= LEVEL_THRESHOLDS.L3 && signals.verifier.present && signals.stateFile.present && !costReady) {
         findings.push({
             level: 'warn',
             message: 'Score qualifies for L3 but cost observability is incomplete — capped at L2 until budget + run log + LOOP.md budget exist.',
         });
     }
-    if (score >= 78 && signals.verifier.present && signals.stateFile.present && costReady && !signals.loopActivity.present) {
+    if (score >= LEVEL_THRESHOLDS.L3 && signals.verifier.present && signals.stateFile.present && costReady && !signals.loopActivity.present) {
         findings.push({
             level: 'warn',
             message: 'Score qualifies for L3 but no proven loop activity yet — capped at L2 until you run and commit at least one loop cycle.',

--- a/tools/loop-audit/src/auditor.ts
+++ b/tools/loop-audit/src/auditor.ts
@@ -64,6 +64,45 @@ const LOOP_SKILL_NAMES = [
   'issue-triage',
 ];
 
+/**
+ * Score contribution for each readiness signal, out of 100.
+ *
+ * These weights are intentionally centralized (rather than inlined in
+ * `computeScore`) so the rubric is auditable in one place and the
+ * level thresholds below stay meaningful when weights change.
+ * `base` is the floor every project starts from. The remaining weights
+ * sum (with `base`) to 100 when every signal is present.
+ */
+const SCORE_WEIGHTS = {
+  base: 10,
+  stateFile: 18,
+  triage: 14,
+  loopConfig: 9,
+  agentsMd: 9,
+  skillsTwoPlus: 14,
+  skillsOne: 7,
+  verifier: 14,
+  safetyLoopMd: 4,
+  safetyDoc: 4,
+  github: 6,
+  githubWorkflows: 4,
+  mcp: 3,
+  worktree: 3,
+  registry: 2,
+  budgetDoc: 3,
+  runLog: 3,
+  loopMdBudget: 2,
+  budgetSkill: 2,
+  loopActivity: 6,
+} as const;
+
+/** Minimum total score required to reach each readiness level (gated by additional signal requirements in `computeScore`). */
+const LEVEL_THRESHOLDS = {
+  L1: 38,
+  L2: 58,
+  L3: 78,
+} as const;
+
 const SAFETY_FILES = ['safety.md', 'docs/safety.md', 'SECURITY.md'];
 const MCP_FILES = ['.mcp.json', 'mcp.json', '.mcp/config.json'];
 const WORKTREE_HINTS = ['worktree', 'worktrees', 'git worktree'];
@@ -163,7 +202,7 @@ async function detectLoopActivity(root: string): Promise<{ present: boolean; evi
       timeout: 1500,
     });
     const lower = log.toLowerCase();
-    if (/state\.md|loop| t riage |changelog-drafter|post-merge|daily triage|audit/i.test(lower)) {
+    if (/state\.md|loop|triage|changelog-drafter|post-merge|daily triage|audit/i.test(lower)) {
       const firstMatch = log.trim().split('\n')[0] || '';
       evidence.push(`git:${firstMatch.slice(0, 60)}`);
     }
@@ -184,27 +223,28 @@ async function detectLoopActivity(root: string): Promise<{ present: boolean; evi
 }
 
 export function computeScore(signals: LoopSignals): { score: number; level: 'L0' | 'L1' | 'L2' | 'L3'; assessment: string } {
-  let score = 10;
+  const w = SCORE_WEIGHTS;
+  let score: number = w.base;
 
-  if (signals.stateFile.present) score += 18;
-  if (signals.triage.present) score += 14;
-  if (signals.loopConfig.present) score += 9;
-  if (signals.agentsMd.present) score += 9;
-  if (signals.skills.count >= 2) score += 14;
-  else if (signals.skills.count === 1) score += 7;
-  if (signals.verifier.present) score += 14;
-  if (signals.safety.loopMdMentionsSafety) score += 4;
-  if (signals.safety.safetyDocPresent) score += 4;
-  if (signals.github.present) score += 6;
-  if (signals.github.workflows) score += 4;
-  if (signals.mcp.present) score += 3;
-  if (signals.worktreeEvidence.present) score += 3;
-  if (signals.registry.present) score += 2;
-  if (signals.cost.budgetDoc) score += 3;
-  if (signals.cost.runLog) score += 3;
-  if (signals.cost.loopMdBudget) score += 2;
-  if (signals.cost.budgetSkill) score += 2;
-  if (signals.loopActivity.present) score += 6;
+  if (signals.stateFile.present) score += w.stateFile;
+  if (signals.triage.present) score += w.triage;
+  if (signals.loopConfig.present) score += w.loopConfig;
+  if (signals.agentsMd.present) score += w.agentsMd;
+  if (signals.skills.count >= 2) score += w.skillsTwoPlus;
+  else if (signals.skills.count === 1) score += w.skillsOne;
+  if (signals.verifier.present) score += w.verifier;
+  if (signals.safety.loopMdMentionsSafety) score += w.safetyLoopMd;
+  if (signals.safety.safetyDocPresent) score += w.safetyDoc;
+  if (signals.github.present) score += w.github;
+  if (signals.github.workflows) score += w.githubWorkflows;
+  if (signals.mcp.present) score += w.mcp;
+  if (signals.worktreeEvidence.present) score += w.worktree;
+  if (signals.registry.present) score += w.registry;
+  if (signals.cost.budgetDoc) score += w.budgetDoc;
+  if (signals.cost.runLog) score += w.runLog;
+  if (signals.cost.loopMdBudget) score += w.loopMdBudget;
+  if (signals.cost.budgetSkill) score += w.budgetSkill;
+  if (signals.loopActivity.present) score += w.loopActivity;
 
   score = Math.min(100, Math.max(0, score));
 
@@ -216,9 +256,9 @@ export function computeScore(signals: LoopSignals): { score: number; level: 'L0'
   const l3Ready = costReady && hasRealActivity;
 
   let level: 'L0' | 'L1' | 'L2' | 'L3' = 'L0';
-  if (score >= 78 && signals.verifier.present && signals.stateFile.present && l3Ready) level = 'L3';
-  else if (score >= 58 && signals.triage.present) level = 'L2';
-  else if (score >= 38 && signals.stateFile.present) level = 'L1';
+  if (score >= LEVEL_THRESHOLDS.L3 && signals.verifier.present && signals.stateFile.present && l3Ready) level = 'L3';
+  else if (score >= LEVEL_THRESHOLDS.L2 && signals.triage.present) level = 'L2';
+  else if (score >= LEVEL_THRESHOLDS.L1 && signals.stateFile.present) level = 'L1';
   else level = 'L0';
 
   const assessment =
@@ -452,14 +492,14 @@ export async function auditProject(target: string): Promise<AuditResult> {
     signals.cost.runLog &&
     signals.cost.loopMdBudget;
 
-  if (score >= 78 && signals.verifier.present && signals.stateFile.present && !costReady) {
+  if (score >= LEVEL_THRESHOLDS.L3 && signals.verifier.present && signals.stateFile.present && !costReady) {
     findings.push({
       level: 'warn',
       message: 'Score qualifies for L3 but cost observability is incomplete — capped at L2 until budget + run log + LOOP.md budget exist.',
     });
   }
 
-  if (score >= 78 && signals.verifier.present && signals.stateFile.present && costReady && !signals.loopActivity.present) {
+  if (score >= LEVEL_THRESHOLDS.L3 && signals.verifier.present && signals.stateFile.present && costReady && !signals.loopActivity.present) {
     findings.push({
       level: 'warn',
       message: 'Score qualifies for L3 but no proven loop activity yet — capped at L2 until you run and commit at least one loop cycle.',

--- a/tools/loop-audit/test/auditor.test.mjs
+++ b/tools/loop-audit/test/auditor.test.mjs
@@ -1,9 +1,25 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { auditProject, computeScore } from '../dist/auditor.js';
+
+/** Initialize a throwaway git repo with one commit. Returns false if git is unavailable. */
+function initGitRepo(dir, commitMessage) {
+  try {
+    const opts = { cwd: dir, stdio: 'ignore' };
+    execFileSync('git', ['init', '-q'], opts);
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], opts);
+    execFileSync('git', ['config', 'user.name', 'Test'], opts);
+    execFileSync('git', ['add', '-A'], opts);
+    execFileSync('git', ['commit', '-q', '-m', commitMessage], opts);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function emptySignals() {
   return {
@@ -149,6 +165,31 @@ test('auditProject: L2 with verifier skill', async () => {
     const result = await auditProject(dir);
     assert.equal(result.level, 'L2');
     assert.ok(result.signals.verifier.present);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('detectLoopActivity: git commit mentioning "triage" is recognized as activity', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loop-audit-git-'));
+  try {
+    // Only signal is the commit subject — the word "triage" with no other
+    // git-detectable token. Regresses the prior `t riage` (spaced) bug, which
+    // could never match a real commit message.
+    await writeFile(path.join(dir, 'notes.txt'), 'work\n');
+    if (!initGitRepo(dir, 'chore: triage the inbox')) {
+      // git not available in this environment — skip without failing
+      return;
+    }
+    const result = await auditProject(dir);
+    assert.ok(
+      result.signals.loopActivity.present,
+      'expected loop activity to be detected from a triage commit',
+    );
+    assert.ok(
+      result.signals.loopActivity.evidence.some((e) => e.startsWith('git:')),
+      `expected git evidence, got: ${JSON.stringify(result.signals.loopActivity.evidence)}`,
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tools/loop-cost/dist/cli.js
+++ b/tools/loop-cost/dist/cli.js
@@ -75,6 +75,11 @@ Examples:
 `);
         process.exit(0);
     }
+    const validLevels = ['L1', 'L2', 'L3'];
+    if (!validLevels.includes(args.level)) {
+        console.error(`Unknown level: ${args.level}. Valid levels: ${validLevels.join(', ')}`);
+        process.exit(1);
+    }
     const registry = await loadRegistry();
     if (args.list) {
         for (const p of registry.patterns) {

--- a/tools/loop-cost/dist/estimator.js
+++ b/tools/loop-cost/dist/estimator.js
@@ -61,7 +61,11 @@ function formatTokens(n) {
         return `${Math.round(n / 1_000)}k`;
     return String(n);
 }
+const VALID_LEVELS = ['L1', 'L2', 'L3'];
 export function estimateCost(input) {
+    if (!VALID_LEVELS.includes(input.level)) {
+        throw new Error(`Invalid readiness level: ${input.level}. Expected one of ${VALID_LEVELS.join(', ')}.`);
+    }
     const cadence = input.cadence ?? input.pattern.cadence;
     const runsPerDay = cadenceToRunsPerDay(cadence, input.conservative);
     const { cost, token_cost: tokenCostTier } = input.pattern;

--- a/tools/loop-cost/src/cli.ts
+++ b/tools/loop-cost/src/cli.ts
@@ -80,6 +80,12 @@ Examples:
     process.exit(0);
   }
 
+  const validLevels: ReadinessLevel[] = ['L1', 'L2', 'L3'];
+  if (!validLevels.includes(args.level)) {
+    console.error(`Unknown level: ${args.level}. Valid levels: ${validLevels.join(', ')}`);
+    process.exit(1);
+  }
+
   const registry = await loadRegistry();
 
   if (args.list) {

--- a/tools/loop-cost/src/estimator.ts
+++ b/tools/loop-cost/src/estimator.ts
@@ -116,7 +116,12 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
+const VALID_LEVELS: readonly ReadinessLevel[] = ['L1', 'L2', 'L3'];
+
 export function estimateCost(input: EstimateInput): EstimateResult {
+  if (!VALID_LEVELS.includes(input.level)) {
+    throw new Error(`Invalid readiness level: ${input.level}. Expected one of ${VALID_LEVELS.join(', ')}.`);
+  }
   const cadence = input.cadence ?? input.pattern.cadence;
   const runsPerDay = cadenceToRunsPerDay(cadence, input.conservative);
   const { cost, token_cost: tokenCostTier } = input.pattern;

--- a/tools/loop-cost/test/estimator.test.mjs
+++ b/tools/loop-cost/test/estimator.test.mjs
@@ -48,6 +48,13 @@ test('estimateCost: ci-sweeper 15m L2 warns on high spend', () => {
   assert.ok(r.scenarios.realistic.tokensPerDay < r.scenarios.action.tokensPerDay);
 });
 
+test('estimateCost: rejects an invalid readiness level', () => {
+  assert.throws(
+    () => estimateCost({ pattern: CI_SWEEPER, level: 'L9' }),
+    /Invalid readiness level/,
+  );
+});
+
 test('estimateCost: daily-triage 1d L1 is cheap', () => {
   const r = estimateCost({
     pattern: {

--- a/tools/loop-init/dist/cli.js
+++ b/tools/loop-init/dist/cli.js
@@ -276,6 +276,16 @@ Examples:
         process.exit(0);
     }
     const { pattern, tool, target, dryRun } = args;
+    const validPatterns = Object.keys(PATTERN_STARTERS);
+    if (!validPatterns.includes(pattern)) {
+        console.error(`Unknown pattern: ${pattern}\nValid patterns: ${validPatterns.join(', ')}`);
+        process.exit(1);
+    }
+    const validTools = Object.keys(TOOL_SUFFIX);
+    if (!validTools.includes(tool)) {
+        console.error(`Unknown tool: ${tool}\nValid tools: ${validTools.join(', ')}`);
+        process.exit(1);
+    }
     const targetDir = path.resolve(target);
     const baseStarter = PATTERN_STARTERS[pattern];
     const suffix = TOOL_SUFFIX[tool];

--- a/tools/loop-init/src/cli.ts
+++ b/tools/loop-init/src/cli.ts
@@ -330,6 +330,19 @@ Examples:
   }
 
   const { pattern, tool, target, dryRun } = args;
+
+  const validPatterns = Object.keys(PATTERN_STARTERS) as Pattern[];
+  if (!validPatterns.includes(pattern)) {
+    console.error(`Unknown pattern: ${pattern}\nValid patterns: ${validPatterns.join(', ')}`);
+    process.exit(1);
+  }
+
+  const validTools = Object.keys(TOOL_SUFFIX) as Tool[];
+  if (!validTools.includes(tool)) {
+    console.error(`Unknown tool: ${tool}\nValid tools: ${validTools.join(', ')}`);
+    process.exit(1);
+  }
+
   const targetDir = path.resolve(target);
   const baseStarter = PATTERN_STARTERS[pattern];
   const suffix = TOOL_SUFFIX[tool];

--- a/tools/loop-init/test/cli.test.mjs
+++ b/tools/loop-init/test/cli.test.mjs
@@ -14,6 +14,30 @@ test('loop-init --help exits 0', async () => {
   assert.match(stdout, /changelog-drafter/);
 });
 
+test('loop-init rejects an unknown pattern with a helpful message', async () => {
+  await assert.rejects(
+    exec('node', [CLI, '.', '--pattern', 'not-a-pattern', '--dry-run']),
+    (err) => {
+      assert.equal(err.code, 1);
+      assert.match(err.stderr, /Unknown pattern: not-a-pattern/);
+      assert.match(err.stderr, /Valid patterns:/);
+      return true;
+    },
+  );
+});
+
+test('loop-init rejects an unknown tool with a helpful message', async () => {
+  await assert.rejects(
+    exec('node', [CLI, '.', '--pattern', 'daily-triage', '--tool', 'emacs', '--dry-run']),
+    (err) => {
+      assert.equal(err.code, 1);
+      assert.match(err.stderr, /Unknown tool: emacs/);
+      assert.match(err.stderr, /Valid tools:/);
+      return true;
+    },
+  );
+});
+
 test('loop-init dry-run scaffolds daily-triage', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'loop-init-'));
   try {


### PR DESCRIPTION
## Summary

Four focused correctness/maintainability fixes to the tooling and the dogfood workflow, found while reading through the repo. Each is a separate commit so they can be reviewed (or cherry-picked) independently. All package test suites pass: **loop-audit 10/10, loop-init 6/6, loop-cost 7/7**.

| # | Area | Type | Commit |
|---|------|------|--------|
| 1 | `loop-audit` | bug + refactor | `fix(loop-audit): repair dead triage regex + centralize scoring weights` |
| 2 | `loop-cost` | bug | `fix(loop-cost): validate --level instead of silently defaulting to L3` |
| 3 | `loop-init` | robustness | `fix(loop-init): reject unknown --pattern / --tool with a clear error` |
| 4 | `daily-triage.yml` | safety | `fix(ci): derive daily-triage commit statuses from real gate outcomes` |

---

### 1. `loop-audit` — dead `t riage` regex (bug) + magic-number scoring (refactor)

**Bug:** In `detectLoopActivity()`, the git-history scan matched the literal `` t riage `` (spaces around it *and* a space inside the word) instead of `triage`:

```js
// before
if (/state\.md|loop| t riage |changelog-drafter|post-merge|daily triage|audit/i.test(lower)) {
// after
if (/state\.md|loop|triage|changelog-drafter|post-merge|daily triage|audit/i.test(lower)) {
```

That alternation branch could never match a real commit subject, so plain `triage` commits were silently not counted as loop activity. It looked fine only because adjacent terms (`loop`/`audit`/`state.md`) masked it — the existing tests asserted the *outcome*, not the *mechanism*. Added a regression test that inits a temp git repo with a single `triage` commit and asserts git evidence is detected (skips gracefully when git is unavailable).

**Refactor (no behavior change):** the `+18/+14/+9…` score contributions and the `38/58/78` level cutoffs were inlined as magic numbers, and the L3 threshold (`78`) was duplicated across `computeScore()` and `auditProject()` — easy to desync. Extracted into documented `SCORE_WEIGHTS` and `LEVEL_THRESHOLDS` constants. Values are identical; the existing L0/L1/L2/L3 boundary tests pass unmodified, proving parity.

### 2. `loop-cost` — `--level` silently defaulted to L3

`--level garbage` was cast to `ReadinessLevel` and flowed into `realisticMix()`, whose if/else has no matching branch and **falls through to the L3 return** — a confident, wrong estimate. Now the CLI rejects an unknown level with a friendly message, and `estimateCost()` also guards at the library boundary (throws) so programmatic callers can't hit the silent fallthrough. Added a test.

### 3. `loop-init` — unknown `--pattern` / `--tool` produced a confusing failure

`parseArgs()` cast both straight to their union types with no validation, so a typo like `--tool emacs` flowed into an undefined record lookup. Now validated against the existing `PATTERN_STARTERS` / `TOOL_SUFFIX` keys (no duplicated lists) with `exit 1` and the list of valid values. Added two CLI tests.

### 4. `daily-triage.yml` — the loop marked its own homework green

The daily-triage loop posted `validate` and `audit` commit statuses as a **hardcoded `state: 'success'`** to satisfy branch protection, then auto-merged its own PR. Since the green statuses were unconditional, the loop could merge itself regardless of whether the real gates passed — the unattended-without-verification failure mode that `docs/safety.md` and `docs/concepts.md` (comprehension debt) explicitly warn about. The real gate scripts were already run in the job, but their results were ignored.

This keeps the automation (statuses still need posting because `GITHUB_TOKEN`-pushed commits don't trigger PR workflows) but makes it **honest**:

- The two gate steps now run with `continue-on-error` + an explicit `id`; a follow-up step fails the run if either gate failed, so no PR is opened or merged on a red gate.
- The commit-status step derives each `state` from the gate's real `steps.<id>.outcome` instead of a literal `'success'`. Green can only be posted when the gate actually passed.

Blast radius was already small (only `STATE.md` + `loop-run-log.md`), but this aligns the reference repo's own loop with the verifier discipline it teaches. *(Happy to split #4 into a separate PR or downgrade it to an issue if you'd prefer to discuss the workflow change on its own — it's the one opinionated change here.)*

---

## Testing

```
loop-audit:  10 passed   (incl. new triage-commit activity regression test)
loop-init:    6 passed   (incl. 2 new --pattern/--tool validation tests)
loop-cost:    7 passed   (incl. new invalid-level test)
```

Compiled `dist/` is committed alongside each source change (the packages publish from committed `dist/`, and the test suites import from `dist/`), so the npm artifacts stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
