### PR TITLE
fix(release): OIDC-only npm publish

### DIFF
--- a/.github/workflows/release-loop-audit.yml
+++ b/.github/workflows/release-loop-audit.yml
@@ -32,8 +32,6 @@ jobs:
           npm run build
           npm test
 
-      - name: Publish to npm
+      - name: Publish to npm (OIDC trusted publishing)
         working-directory: tools/loop-audit
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-loop-cost.yml
+++ b/.github/workflows/release-loop-cost.yml
@@ -32,8 +32,6 @@ jobs:
           npm run build
           npm test
 
-      - name: Publish to npm
+      - name: Publish to npm (OIDC trusted publishing)
         working-directory: tools/loop-cost
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-loop-init.yml
+++ b/.github/workflows/release-loop-init.yml
@@ -29,5 +29,3 @@ jobs:
           npm ci
           npm test
           npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -20,7 +20,7 @@ Link npm to GitHub, then for **each package** on [npmjs.com](https://www.npmjs.c
 
 Names must match **exactly** (case-sensitive). No `NPM_TOKEN` secret is required when trusted publishing is configured.
 
-**Legacy fallback:** add an npm Automation token as repo secret `NPM_TOKEN` and restore `NODE_AUTH_TOKEN` in the publish steps.
+**Legacy fallback:** add an npm Automation token as repo secret `NPM_TOKEN` and set `NODE_AUTH_TOKEN` in the publish steps. Do **not** set `NODE_AUTH_TOKEN` when trusted publishing is active — an expired token overrides OIDC and causes `E404` on publish.
 
 ## Version bump
 


### PR DESCRIPTION
Fixes E404 on tag releases. Expired NPM_TOKEN was overriding OIDC trusted publishing.