### PR TITLE
fix(release): restore NPM_TOKEN + manual retry

### DIFF
--- a/.github/workflows/release-loop-audit.yml
+++ b/.github/workflows/release-loop-audit.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'loop-audit-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. loop-audit-v1.4.2)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
 
       - uses: actions/setup-node@v6
         with:
@@ -32,6 +40,8 @@ jobs:
           npm run build
           npm test
 
-      - name: Publish to npm (OIDC trusted publishing)
+      - name: Publish to npm
         working-directory: tools/loop-audit
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-loop-cost.yml
+++ b/.github/workflows/release-loop-cost.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'loop-cost-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. loop-cost-v1.0.3)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
 
       - uses: actions/setup-node@v6
         with:
@@ -32,6 +40,8 @@ jobs:
           npm run build
           npm test
 
-      - name: Publish to npm (OIDC trusted publishing)
+      - name: Publish to npm
         working-directory: tools/loop-cost
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-loop-init.yml
+++ b/.github/workflows/release-loop-init.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'loop-init-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. loop-init-v1.2.2)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
 
       - uses: actions/setup-node@v6
         with:
@@ -29,3 +37,5 @@ jobs:
           npm ci
           npm test
           npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -20,7 +20,11 @@ Link npm to GitHub, then for **each package** on [npmjs.com](https://www.npmjs.c
 
 Names must match **exactly** (case-sensitive). No `NPM_TOKEN` secret is required when trusted publishing is configured.
 
-**Legacy fallback:** add an npm Automation token as repo secret `NPM_TOKEN` and set `NODE_AUTH_TOKEN` in the publish steps. Do **not** set `NODE_AUTH_TOKEN` when trusted publishing is active — an expired token overrides OIDC and causes `E404` on publish.
+**Auth:** release workflows use repo secret `NPM_TOKEN` (Automation token). Refresh it at [npmjs.com](https://www.npmjs.com/) → Access Tokens if publishes fail with `E401`/`E404`.
+
+**Retry without re-tagging:** Actions → Release workflow → **Run workflow** → enter the tag (e.g. `loop-audit-v1.4.2`).
+
+**Trusted publishing (optional):** configure per package on npm; OIDC alone is not sufficient unless `NPM_TOKEN` is removed and trusted publishers are verified.
 
 ## Version bump
 


### PR DESCRIPTION
Publish failed: expired NPM_TOKEN. Restores token auth and adds workflow_dispatch to retry tags without re-pushing.