### PR TITLE
chore(daily-triage): add post-run critique section

### DIFF
--- a/patterns/daily-triage.md
+++ b/patterns/daily-triage.md
@@ -50,6 +50,17 @@ Fields the loop must update every run:
 4. (Phase 2) For small, self-contained failures: open worktree → implementer → verifier.
 5. (Phase 3) Connectors update PRs/tickets; ambiguous items flagged for human.
 6. Prune resolved/merged items from state.
+7. Record post-run critique in state: false positives, repeated items, re-prioritized or dropped items, and one adjustment for next run.
+
+## Post-Run Critique
+
+After each Daily Triage run, record:
+
+- High-noise items.
+- False positives (items incorrectly flagged).
+- Items that should be deprioritized.
+- Any human-review friction.
+- One change to improve the next cycle.
 
 ## Verification Strategy
 
@@ -90,6 +101,7 @@ Fields the loop must update every run:
 | State file grows unbounded | Prune merged/closed items every run |
 | Auto-fix on wrong priority | Start report-only; add explicit effort/risk gates |
 | Missed overnight failures | Add `fireImmediately: true` or run at start of day + mid-day |
+| Stale critique / never reviewed | Add human handoff when critique entries accumulate without resolution across N runs. |
 
 ## Cost Profile
 

--- a/starters/minimal-loop/STATE.md.example
+++ b/starters/minimal-loop/STATE.md.example
@@ -8,5 +8,12 @@ Last run: never
 
 ## Recent Noise (ignored this run)
 
+## Post-Run Critique (from last run)
+- High-noise: dependabot PRs surfaced again — add to ignore list
+- False positives: 1 CI flake (known flaky test)
+- Deprioritize: lint warnings moved to Watch List
+- Friction: triage missed nightly deploy failure (was infra, not code)
+- Adjustment: include infra check status in scan
+
 ---
 Run log: —


### PR DESCRIPTION
This reuses the critique pattern from Changelog Drafter. Helps report-only loops capture quality issues (high-noise items, incorrect flags, deprioritized items, review friction, and one cycle improvement) before the next run. No autonomy increase.

## Summary
<!-- One sentence what this does and why -->

## Changes
- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example improvement
- [ ] Tool change (loop-audit)
- [ ] Story (includes real failure or surprise + lesson)

## Checklist (from CONTRIBUTING)
- [ ] All required sections present for patterns
- [ ] Links work from README, patterns/README, starters/README, docs/index
- [ ] No secrets, tokens, internal company URLs
- [ ] `STATE.md*` examples use `.example` suffix
- [ ] Safety-related content references `docs/safety.md`
- [ ] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood
- [ ] `loop-audit` passes on affected starters or this repo
- [ ] Manual review of generated state / skill output

## Screenshots / Examples (if UI or command output)
<!-- Paste relevant output or link to rendered docs -->

---

*This template enforces the high bar this reference is known for.*
