### PR TITLE
Add OpenClaw Phase 1: primitives matrix and daily triage example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This repo is a **practical engineering reference**, not a hype collection. We we
 |--------------|-------|
 | New loop pattern | `patterns/` + `patterns/registry.yaml` |
 | Production story | `stories/` |
-| Tool example | `examples/{grok,claude-code,codex,github-actions}/` |
+| Tool example | `examples/{grok,claude-code,codex,openclaw,github-actions}/` |
 | Skill template | `templates/` |
 | Starter kit | `starters/` |
 | Doc improvement | `docs/` |

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Phased rollout: **L1 report → L2 assisted fixes → L3 unattended** — see [l
 - [Grok](examples/grok/daily-triage.md)
 - [Claude Code](examples/claude-code/)
 - [Codex](examples/codex/)
+- [OpenClaw](examples/openclaw/daily-triage.md)
 - [GitHub Actions](examples/github-actions/)
 
 ## Operating & Safety

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -60,6 +60,10 @@ npx @cobusgreyling/loop-audit . --badge
 
 Use the first-run command printed by `loop-init` (pattern-specific). Week one: triage and state updates only.
 
+### OpenClaw
+
+No `loop-init --tool openclaw` yet — copy `skills/loop-triage/SKILL.md` and `STATE.md`, then create an isolated cron job. See [examples/openclaw/daily-triage.md](../examples/openclaw/daily-triage.md).
+
 ### Cursor or Windsurf
 
 No `loop-init --tool cursor` yet — copy skills and state from any starter, then map scheduling to editor Automations or Workflows. See the [Cursor & Windsurf appendix](./primitives-matrix.md#appendix-editor-transfer-recipes-cursor--windsurf) in the primitives matrix.
@@ -103,7 +107,7 @@ npx @cobusgreyling/loop-audit . --badge
 ## Learn the why (optional, 10 minutes)
 
 - [Loop Engineering essay](https://cobusgreyling.substack.com/p/loop-engineering) — concept and primitives
-- [Primitives matrix](./primitives-matrix.md) — Grok vs Claude vs Codex vs Cursor
+- [Primitives matrix](./primitives-matrix.md) — Grok vs Claude vs Codex vs OpenClaw vs Cursor
 - [Operating loops](./operating-loops.md) — when to kill a loop
 
 ---

--- a/docs/assets/css/showcase.css
+++ b/docs/assets/css/showcase.css
@@ -435,6 +435,7 @@ section {
 .tool-pill.grok { border-color: rgba(62, 232, 197, 0.3); color: var(--accent); }
 .tool-pill.claude { border-color: rgba(255, 179, 71, 0.3); color: var(--accent-warm); }
 .tool-pill.codex { border-color: rgba(91, 157, 255, 0.3); color: var(--accent-2); }
+.tool-pill.openclaw { border-color: rgba(255, 107, 107, 0.35); color: #ff8a7a; }
 
 /* Code block */
 .code-block {

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,7 +125,7 @@ title: Loop Engineering — Showcase
 <section id="primitives" class="wrap">
   <p class="section-label">Building blocks</p>
   <h2 class="section-title">Five primitives + memory</h2>
-  <p class="section-desc">The same shape works in Grok, Claude Code, and Codex. Tool names differ; capabilities converge.</p>
+  <p class="section-desc">The same shape works in Grok, Claude Code, Codex, and OpenClaw. Tool names differ; capabilities converge.</p>
   <div class="primitives">
     <div class="primitive">
       <div class="icon">⏱</div>
@@ -162,6 +162,7 @@ title: Loop Engineering — Showcase
     <span class="tool-pill grok">Grok Build</span>
     <span class="tool-pill claude">Claude Code</span>
     <span class="tool-pill codex">Codex</span>
+    <span class="tool-pill openclaw">OpenClaw</span>
     <span class="tool-pill">GitHub Actions</span>
   </div>
   <p style="text-align: center; margin-top: 24px;">

--- a/docs/primitives-matrix.md
+++ b/docs/primitives-matrix.md
@@ -1,42 +1,42 @@
-# Primitives Matrix — Grok, Claude Code, Codex, Cursor, Windsurf
+# Primitives Matrix — Grok, Claude Code, Codex, OpenClaw, Cursor, Windsurf
 
-Tool-agnostic loop design: the **capability** is what matters, not the product name. This matrix maps each primitive to how it appears in five major agent environments.
+Tool-agnostic loop design: the **capability** is what matters, not the product name. This matrix maps each primitive to how it appears in six major agent environments.
 
-| Primitive | Job in the Loop | Grok Build TUI | Claude Code | Codex | Cursor | Windsurf |
-|-----------|-----------------|----------------|-------------|-------|--------|----------|
-| **Automations / Scheduling** | Discovery + triage on a cadence | `/loop [interval] <prompt>`, `scheduler_create` / `scheduler_list` / `scheduler_delete` (`recurring`, `durable`, `fireImmediately`), `monitor` for streaming events | `/loop`, scheduled tasks, cron, hooks, GitHub Actions | [Automations tab](https://developers.openai.com/codex/app/automations): project, prompt, cadence, environment; Triage inbox | Cloud Agents + **Automations** (cron, webhooks, Linear/GitHub/Slack triggers); foreground Agent chat for ad-hoc `/loop`-style prompts | Cascade **Workflows** (`/workflow-name`, manual invoke); pair with GitHub Actions or external cron for true scheduling |
-| **Run-until-done** | Keep working until a verifiable condition holds | [`/goal`](https://github.com/cobusgreyling/goal-engineering) + `update_goal` — persistent objective across turns ([Goal Engineering](https://github.com/cobusgreyling/goal-engineering)) | `/goal` — separate model checks completion | `/goal` — pause/resume, verifiable stop condition | Agent mode + **hooks** (`.cursor/hooks.json`) for grind-until-green loops | Workflow steps with explicit verification checkpoints; **Memories** for cross-session continuity |
-| **Worktrees** | Safe parallel execution | Subagents with `isolation: "worktree"`, background tasks | `git worktree`, `--worktree`, `isolation: worktree` on subagents | Built-in worktree per thread | Git worktree per Composer / Cloud Agent task | Workspace isolation; multiple simultaneous Cascade sessions |
-| **Skills** | Persistent project knowledge | `SKILL.md` in `.grok/skills/` or `~/.grok/skills/`; invoked by name | `SKILL.md` in `.claude/skills/` or project skills | [Agent Skills](https://developers.openai.com/codex/skills) — `$name` or implicit match | `.cursor/rules/*.mdc` (globs, `alwaysApply`), `AGENTS.md`, `.cursor/skills/` | `.devin/rules/` or `.windsurf/rules/` (persistent context); `.windsurf/workflows/` (reusable recipes) |
-| **Plugins & Connectors** | Reach into real tools | MCP servers via `CallMcpTool` | MCP servers + plugins | Connectors (MCP) + plugins for distribution | MCP in settings; Cloud Agent sandbox with full connector access | MCP via Cascade settings / `mcp_config.json` |
-| **Sub-agents** | Maker / checker split | `Task` tool with `subagent_type`, worktree isolation | Task subagents in `.claude/agents/`, agent teams | Subagents as TOML in `.codex/agents/` | Multi-agent mode, review mode, custom agents in `.cursor/agents/` | Multiple Cascades in parallel; workflow-orchestrated implementer → reviewer steps |
-| **State / Memory** | Track what's done across runs | `STATE.md`, todos, durable scheduler state | `AGENTS.md`, progress files, Linear via MCP | Markdown or Linear via connector | `STATE.md`, `LOOP.md`, Cloud Agent memories | `STATE.md`, Cascade **Memories**, workflow run notes |
+| Primitive | Job in the Loop | Grok Build TUI | Claude Code | Codex | OpenClaw | Cursor | Windsurf |
+|-----------|-----------------|----------------|-------------|-------|----------|--------|----------|
+| **Automations / Scheduling** | Discovery + triage on a cadence | `/loop [interval] <prompt>`, `scheduler_create` / `scheduler_list` / `scheduler_delete` (`recurring`, `durable`, `fireImmediately`), `monitor` for streaming events | `/loop`, scheduled tasks, cron, hooks, GitHub Actions | [Automations tab](https://developers.openai.com/codex/app/automations): project, prompt, cadence, environment; Triage inbox | [`openclaw cron`](https://docs.openclaw.ai/automation/cron-jobs) (`--cron` / `--every` / `--at`, isolated or main session); webhooks (`POST /hooks/agent`, `/hooks/wake`); heartbeat | Cloud Agents + **Automations** (cron, webhooks, Linear/GitHub/Slack triggers); foreground Agent chat for ad-hoc `/loop`-style prompts | Cascade **Workflows** (`/workflow-name`, manual invoke); pair with GitHub Actions or external cron for true scheduling |
+| **Run-until-done** | Keep working until a verifiable condition holds | [`/goal`](https://github.com/cobusgreyling/goal-engineering) + `update_goal` — persistent objective across turns ([Goal Engineering](https://github.com/cobusgreyling/goal-engineering)) | `/goal` — separate model checks completion | `/goal` — pause/resume, verifiable stop condition | Recurring isolated cron with explicit stop condition in `--message`; delegate via `coding-agent` skill to external CLI; hand off bounded work to Goal Engineering | Agent mode + **hooks** (`.cursor/hooks.json`) for grind-until-green loops | Workflow steps with explicit verification checkpoints; **Memories** for cross-session continuity |
+| **Worktrees** | Safe parallel execution | Subagents with `isolation: "worktree"`, background tasks | `git worktree`, `--worktree`, `isolation: worktree` on subagents | Built-in worktree per thread | `exec` + `git worktree` in agent workspace; `coding-agent` delegates to CLI backends; optional sandbox per agent | Git worktree per Composer / Cloud Agent task | Workspace isolation; multiple simultaneous Cascade sessions |
+| **Skills** | Persistent project knowledge | `SKILL.md` in `.grok/skills/` or `~/.grok/skills/`; invoked by name | `SKILL.md` in `.claude/skills/` or project skills | [Agent Skills](https://developers.openai.com/codex/skills) — `$name` or implicit match | `SKILL.md` in `<workspace>/skills/`, `.agents/skills`, or `~/.openclaw/skills`; [AgentSkills](https://agentskills.io) spec; [ClawHub](https://clawhub.ai) + `openclaw skills install` | `.cursor/rules/*.mdc` (globs, `alwaysApply`), `AGENTS.md`, `.cursor/skills/` | `.devin/rules/` or `.windsurf/rules/` (persistent context); `.windsurf/workflows/` (reusable recipes) |
+| **Plugins & Connectors** | Reach into real tools | MCP servers via `CallMcpTool` | MCP servers + plugins | Connectors (MCP) + plugins for distribution | MCP + channel plugins (Slack, Telegram, WhatsApp, etc.); browser automation plugin | MCP in settings; Cloud Agent sandbox with full connector access | MCP via Cascade settings / `mcp_config.json` |
+| **Sub-agents** | Maker / checker split | `Task` tool with `subagent_type`, worktree isolation | Task subagents in `.claude/agents/`, agent teams | Subagents as TOML in `.codex/agents/` | `agents.list` multi-agent routing; isolated cron subagent orchestration; separate verifier agent id | Multi-agent mode, review mode, custom agents in `.cursor/agents/` | Multiple Cascades in parallel; workflow-orchestrated implementer → reviewer steps |
+| **State / Memory** | Track what's done across runs | `STATE.md`, todos, durable scheduler state | `AGENTS.md`, progress files, Linear via MCP | Markdown or Linear via connector | `STATE.md`, `HEARTBEAT.md` in workspace; cron persisted in Gateway SQLite; Skill Workshop for skill proposals | `STATE.md`, `LOOP.md`, Cloud Agent memories | `STATE.md`, Cascade **Memories**, workflow run notes |
 
 ## Scheduling Quick Reference
 
-| Use case | Grok | Claude Code | Codex | Cursor | Windsurf |
-|----------|------|-------------|-------|--------|----------|
-| Every 5 minutes | `/loop 5m <prompt>` | `/loop 5m <prompt>` | Automation, 5m cadence | Automation cron trigger | External cron + `/workflow` or Action |
-| Daily morning | `/loop 1d <prompt>` | Cron / `/loop 1d` | Automation, daily | Automation daily + `AGENTS.md` context | Daily workflow + Memories |
-| Until tests pass | [`/goal`](https://github.com/cobusgreyling/goal-engineering/blob/main/patterns/tests-green.md) + `goal-verifier` skill (or loop + verifier) | `/goal all tests pass` | `/goal` | Hooks grind-until-green | Workflow with test/fix loop |
-| Survive restart | `scheduler_create` with `durable: true` | Hooks + persisted config | Automation (server-side) | Cloud Agent + repo-persisted state | Memories + committed `STATE.md` |
-| Event-driven (CI fail) | `monitor` or GitHub Action | GitHub Action + webhook | Automation + webhook | Automation on PR/issue events | GitHub Action triggers + `/workflow` |
+| Use case | Grok | Claude Code | Codex | OpenClaw | Cursor | Windsurf |
+|----------|------|-------------|-------|----------|--------|----------|
+| Every 5 minutes | `/loop 5m <prompt>` | `/loop 5m <prompt>` | Automation, 5m cadence | `openclaw cron create "*/5 * * * *" --session isolated --message "..."` | Automation cron trigger | External cron + `/workflow` or Action |
+| Daily morning | `/loop 1d <prompt>` | Cron / `/loop 1d` | Automation, daily | `openclaw cron create "0 7 * * *" --tz ... --session isolated` + optional `--announce` | Automation daily + `AGENTS.md` context | Daily workflow + Memories |
+| Until tests pass | [`/goal`](https://github.com/cobusgreyling/goal-engineering/blob/main/patterns/tests-green.md) + `goal-verifier` skill (or loop + verifier) | `/goal all tests pass` | `/goal` | Isolated cron + verifier in message, or `coding-agent` + external CLI | Hooks grind-until-green | Workflow with test/fix loop |
+| Survive restart | `scheduler_create` with `durable: true` | Hooks + persisted config | Automation (server-side) | Cron jobs persist in Gateway SQLite | Cloud Agent + repo-persisted state | Memories + committed `STATE.md` |
+| Event-driven (CI fail) | `monitor` or GitHub Action | GitHub Action + webhook | Automation + webhook | `POST /hooks/agent` or mapped webhooks | Automation on PR/issue events | GitHub Action triggers + `/workflow` |
 
 ## Skill Packaging
 
-| Concept | Grok | Claude Code | Codex | Cursor | Windsurf |
-|---------|------|-------------|-------|--------|----------|
-| Authoring format | `SKILL.md` + optional scripts/references | Same | Same | `SKILL.md` or `.mdc` rules with frontmatter | Markdown rules + workflow files |
-| Distribution | Copy to `.grok/skills/` or user skills dir | Plugin / copy to project | Plugin bundle | `.cursor/skills/` or `.cursor/rules/` | `.windsurf/rules/` + `.windsurf/workflows/` in repo |
-| Invocation | Skill name in prompt or auto-match on description | `$skill-name` or implicit | `$skill-name` | Rules auto-apply by glob; skills on demand | `/workflow-name` or Rules always-on in Cascade |
+| Concept | Grok | Claude Code | Codex | OpenClaw | Cursor | Windsurf |
+|---------|------|-------------|-------|----------|--------|----------|
+| Authoring format | `SKILL.md` + optional scripts/references | Same | Same | Same ([AgentSkills](https://agentskills.io)) | `SKILL.md` or `.mdc` rules with frontmatter | Markdown rules + workflow files |
+| Distribution | Copy to `.grok/skills/` or user skills dir | Plugin / copy to project | Plugin bundle | `<workspace>/skills/`, ClawHub, `openclaw skills install` | `.cursor/skills/` or `.cursor/rules/` | `.windsurf/rules/` + `.windsurf/workflows/` in repo |
+| Invocation | Skill name in prompt or auto-match on description | `$skill-name` or implicit | `$skill-name` | Slash command or auto-injected in system prompt | Rules auto-apply by glob; skills on demand | `/workflow-name` or Rules always-on in Cascade |
 
 ## Sub-agent Patterns
 
-| Split | When to use | Grok | Claude Code | Codex | Cursor | Windsurf |
-|-------|-------------|------|-------------|-------|--------|----------|
-| Implementer → Verifier | Any unattended code change | `Task` + different instructions/model | `.claude/agents/reviewer.md` | TOML agent with higher `reasoning_effort` | Review mode or second Cloud Agent pass | Second Cascade or workflow review step |
-| Explorer → Implementer | Large unfamiliar codebase | `explore` subagent_type | Explorer agent | Fast read-only subagent | `@codebase` + plan mode first | Audit workflow (read-only) then implement |
-| Triage only | Report-first loops | `loop-triage` skill | `$loop-triage` | Automation calls skill | `AGENTS.md` + report-only rule | Triage workflow, no edit steps |
+| Split | When to use | Grok | Claude Code | Codex | OpenClaw | Cursor | Windsurf |
+|-------|-------------|------|-------------|-------|----------|--------|----------|
+| Implementer → Verifier | Any unattended code change | `Task` + different instructions/model | `.claude/agents/reviewer.md` | TOML agent with higher `reasoning_effort` | Separate `agents.list` id or verifier block in cron message | Review mode or second Cloud Agent pass | Second Cascade or workflow review step |
+| Explorer → Implementer | Large unfamiliar codebase | `explore` subagent_type | Explorer agent | Fast read-only subagent | `--light-context` cron + follow-up isolated job | `@codebase` + plan mode first | Audit workflow (read-only) then implement |
+| Triage only | Report-first loops | `loop-triage` skill | `$loop-triage` | Automation calls skill | `loop-triage` + isolated cron; restrict `--tools` | `AGENTS.md` + report-only rule | Triage workflow, no edit steps |
 
 ## State Conventions
 
@@ -70,6 +70,7 @@ See [examples/](../examples/) for the same pattern implemented across tools.
 | Grok | [starters/minimal-loop](../starters/minimal-loop/) |
 | Claude Code | [starters/minimal-loop-claude](../starters/minimal-loop-claude/) |
 | Codex | [starters/minimal-loop-codex](../starters/minimal-loop-codex/) |
+| OpenClaw | [examples/openclaw/daily-triage.md](../examples/openclaw/daily-triage.md) — copy `skills/` + `STATE.md`; no `loop-init` yet |
 | Cursor / Windsurf | Copy `SKILL.md` + `STATE.md` from any starter; map scheduling to editor Automations or Workflows (see appendix) |
 
 Audit after copying: `npx @cobusgreyling/loop-audit . --suggest`

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ Same patterns, different tools. Skills and state schemas are shared; only schedu
 | Grok Build TUI | [grok/](./grok/) |
 | Claude Code | [claude-code/](./claude-code/) |
 | Codex App | [codex/](./codex/) |
+| OpenClaw | [openclaw/](./openclaw/) |
 | GitHub Actions | [github-actions/](./github-actions/) |
 | MCP connectors | [mcp/](./mcp/) |
 
@@ -14,9 +15,9 @@ Start with [primitives-matrix.md](../docs/primitives-matrix.md) to map capabilit
 
 ## Pattern coverage
 
-| Pattern | Grok | Claude | Codex | GH Actions |
-|---------|------|--------|-------|------------|
-| Daily Triage | [grok/daily-triage.md](./grok/daily-triage.md) | [claude-code/daily-triage.md](./claude-code/daily-triage.md) | [codex/daily-triage.md](./codex/daily-triage.md) | [github-actions/daily-triage.yml](./github-actions/daily-triage.yml) |
+| Pattern | Grok | Claude | Codex | OpenClaw | GH Actions |
+|---------|------|--------|-------|----------|------------|
+| Daily Triage | [grok/daily-triage.md](./grok/daily-triage.md) | [claude-code/daily-triage.md](./claude-code/daily-triage.md) | [codex/daily-triage.md](./codex/daily-triage.md) | [openclaw/daily-triage.md](./openclaw/daily-triage.md) | [github-actions/daily-triage.yml](./github-actions/daily-triage.yml) |
 | PR Babysitter | [grok/pr-babysitter.md](./grok/pr-babysitter.md) | [claude-code/pr-babysitter.md](./claude-code/pr-babysitter.md) | [codex/pr-babysitter.md](./codex/pr-babysitter.md) | [github-actions/pr-babysitter.yml](./github-actions/pr-babysitter.yml) |
 | CI Sweeper | [grok/ci-sweeper.md](./grok/ci-sweeper.md) | [claude-code/ci-sweeper.md](./claude-code/ci-sweeper.md) | [codex/ci-sweeper.md](./codex/ci-sweeper.md) | [github-actions/ci-sweeper.yml](./github-actions/ci-sweeper.yml) |
 | Post-Merge Cleanup | [grok/post-merge-cleanup.md](./grok/post-merge-cleanup.md) | [claude-code/post-merge-cleanup.md](./claude-code/post-merge-cleanup.md) | [codex/post-merge-cleanup.md](./codex/post-merge-cleanup.md) | [github-actions/post-merge-cleanup.yml](./github-actions/post-merge-cleanup.yml) |
@@ -33,3 +34,4 @@ L2 patterns ship multi-tool skills inside one starter folder — see `starters/<
 | Grok | [starters/minimal-loop](../starters/minimal-loop/) |
 | Claude Code | [starters/minimal-loop-claude](../starters/minimal-loop-claude/) |
 | Codex | [starters/minimal-loop-codex](../starters/minimal-loop-codex/) |
+| OpenClaw | [openclaw/daily-triage.md](./openclaw/daily-triage.md) (manual setup) |

--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -1,0 +1,11 @@
+# OpenClaw
+
+Self-hosted Gateway: cron scheduling, workspace skills, MCP, multi-agent routing, and optional delivery to Slack/Telegram/WhatsApp.
+
+| Example | Pattern |
+|---------|---------|
+| [daily-triage.md](./daily-triage.md) | Daily Triage (L1 report → L2 assisted) |
+
+No `loop-init --tool openclaw` yet — copy skills and state manually; see [daily-triage.md](./daily-triage.md).
+
+See [docs/primitives-matrix.md](../../docs/primitives-matrix.md).

--- a/examples/openclaw/daily-triage.md
+++ b/examples/openclaw/daily-triage.md
@@ -1,0 +1,102 @@
+# Daily Triage — OpenClaw
+
+Same pattern as Grok and Claude Code; scheduling runs on the **Gateway** (`openclaw cron`) instead of a TUI `/loop`. Optional **channel delivery** (Slack, Telegram, etc.) is the main reason to run triage here.
+
+## Prerequisites
+
+1. [OpenClaw Gateway](https://docs.openclaw.ai/) running with your repo as the agent workspace.
+2. `STATE.md` at the repo root — copy from `starters/minimal-loop/STATE.md.example`.
+3. `loop-triage` skill — copy `templates/SKILL.md.loop-triage` to `<workspace>/skills/loop-triage/SKILL.md` (or `openclaw skills install` from ClawHub once published).
+
+```bash
+mkdir -p skills/loop-triage
+cp templates/SKILL.md.loop-triage skills/loop-triage/SKILL.md
+cp starters/minimal-loop/STATE.md.example STATE.md
+```
+
+## Report-Only (Week 1)
+
+Isolated cron job: fresh session each run, writes to `STATE.md`, no code edits.
+
+```bash
+openclaw cron create "0 7 * * 1-5" \
+  --name "Daily triage" \
+  --tz "America/Los_Angeles" \
+  --session isolated \
+  --message "Run the loop-triage skill. Read STATE.md. Merge findings into High Priority and Watch List. Update Last run timestamp. Do not edit source code. End with a 5-line summary." \
+  --tools read,write,exec \
+  --announce \
+  --channel slack \
+  --to "channel:C1234567890"
+```
+
+Omit `--announce`, `--channel`, and `--to` to keep output in the Gateway only (repo + session).
+
+Faster cadence during active periods:
+
+```bash
+openclaw cron create "0 */2 * * *" \
+  --name "Triage pulse" \
+  --session isolated \
+  --message "Run loop-triage. Report obvious small wins only. Update STATE.md. No code changes."
+```
+
+## With Small Auto-Fixes (Week 3+)
+
+Add a verifier agent (separate `agents.list` entry) or explicit checker instructions in the cron message. Restrict tools until the loop is trusted.
+
+```bash
+openclaw cron edit <job-id> \
+  --message "Run loop-triage. For high-priority single-file bugfixes: create an isolated git worktree, implement minimal fix, run tests, have a verifier pass review the diff. Update STATE.md. Escalate ambiguous or denylisted paths."
+```
+
+Enable the bundled `coding-agent` skill only when delegating to an external CLI (`claude`, `codex`, etc.) is intentional — see [OpenClaw skills config](https://docs.openclaw.ai/tools/skills-config).
+
+## Event-Triggered Triage
+
+Webhook instead of cron — useful after deploys or CI failures:
+
+```bash
+curl -X POST http://127.0.0.1:18789/hooks/agent \
+  -H 'Authorization: Bearer <hooks-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"Run loop-triage on recent CI failures. Update STATE.md. Report only.","name":"CI triage","deliver":false}'
+```
+
+Keep hook endpoints on loopback or a trusted tailnet. See [Scheduled tasks](https://docs.openclaw.ai/automation/cron-jobs) and [Security](https://docs.openclaw.ai/gateway/security).
+
+## Verification Split
+
+| Role | OpenClaw shape |
+|------|----------------|
+| Triage | `loop-triage` skill + isolated cron |
+| Implementer | Main agent or `coding-agent` in worktree via `exec` |
+| Verifier | Second agent id in `agents.list`, or checker block in cron `--message` |
+
+Isolated cron runs prefer **final descendant output** over interim status text — structure verifier work as explicit sub-steps in the message.
+
+## Safety (L1 defaults)
+
+- `--session isolated` — do not pollute human chat history with routine triage turns.
+- Restrict `--tools` on cron jobs until L2 graduation.
+- Channel `allowFrom` / mention rules before enabling `--announce` to DMs or groups.
+- Week one: **report-only**; human reads `STATE.md` and the channel summary.
+
+## Operations
+
+```bash
+openclaw cron list
+openclaw cron runs --id <job-id>
+openclaw cron edit <job-id> --message "..."
+```
+
+Pause: remove or disable the job (`openclaw cron remove <job-id>`) or set `loop-pause-all` in `STATE.md` and teach the skill to stop acting.
+
+Audit readiness: `npx @cobusgreyling/loop-audit . --suggest`
+
+## References
+
+- Peter Steinberger — design loops, not one-off prompts ([sources](../../resources/sources.md))
+- [primitives-matrix.md](../../docs/primitives-matrix.md) — OpenClaw column
+- [patterns/daily-triage.md](../../patterns/daily-triage.md)
+- [docs/safety.md](../../docs/safety.md)


### PR DESCRIPTION
## Summary

- Add OpenClaw column to the primitives matrix (scheduling, skills, sub-agents, state)
- Add `examples/openclaw/daily-triage.md` with isolated-cron L1 setup, optional channel delivery, and webhook trigger
- Link from showcase, README, QUICKSTART, and examples index

## Notes

Phase 1 only — no `loop-init --tool openclaw` or dedicated starter yet. Manual `skills/` + `STATE.md` setup documented in the example.

## Test plan

- [ ] Review `examples/openclaw/daily-triage.md` commands against current OpenClaw cron docs
- [ ] Confirm showcase pill renders on GitHub Pages after merge