### PR TITLE
docs: add Star History chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,13 @@ MIT
   ·
   <a href="https://github.com/cobusgreyling">Cobus Greyling</a>
 </p>
+
+<p align="center">
+  <a href="https://www.star-history.com/?repos=cobusgreyling%2Floop-engineering&type=timeline&legend=top-left">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=cobusgreyling/loop-engineering&type=timeline&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=cobusgreyling/loop-engineering&type=timeline&legend=top-left" />
+      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=cobusgreyling/loop-engineering&type=timeline&legend=top-left" />
+    </picture>
+  </a>
+</p>


### PR DESCRIPTION
Adds a Star History chart at the bottom of the README showing star growth in timeline mode with top-left legend.

Links to: https://www.star-history.com/?repos=cobusgreyling%2Floop-engineering&type=timeline&legend=top-left