### PR TITLE
docs: fix discussion link + highlight community update

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A loop is a recursive goal: you define a purpose and the AI iterates (often with
 | [loop-mcp-server](tools/mcp-server/) | MCP runtime lookup for patterns, skills, state — `node tools/mcp-server/dist/index.js` (repo v1; npm pending) |
 | [Goal Engineering](https://github.com/cobusgreyling/goal-engineering) | Companion: Grok Build `/goal` — run-until-done objectives (`npx @cobusgreyling/goal-audit`) |
 | [Stories](stories/) | Real wins and honest failures |
+| [Community update](https://github.com/cobusgreyling/loop-engineering/discussions/89) | **New:** 7 community PRs merged — loop-sync, constraints, MCP server |
 
 <p align="center">
   <img src="assets/visuals/section-divider.svg" alt="" width="100%" />

--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -39,7 +39,7 @@ Or open a PR that adds a row to the table below:
 
 ## Show & tell
 
-Prefer chat over a PR? Post in [GitHub Discussions → Show your loop](https://github.com/cobusgreyling/loop-engineering/discussions/categories/show-your-loop) with:
+Prefer chat over a PR? Post in [GitHub Discussions → Show and tell](https://github.com/cobusgreyling/loop-engineering/discussions/categories/show-and-tell) with:
 
 1. Which pattern you picked and why
 2. Your first `/loop` or scheduler command


### PR DESCRIPTION
Fixes broken show-your-loop category URL in adopters.md. Adds Discussion #89 to README Quick Links (pin substitute — GitHub API cannot pin discussions).