### PR TITLE
docs: restore LE5 hero image below tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 
 > **Stop prompting. Design the loop. Get a score.**
 
+<p align="center">
+  <img src="assets/visuals/LE5.jpeg" alt="Loop Engineering — design the system that prompts your agents" width="100%" />
+</p>
+
 ```bash
 npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok
 ```


### PR DESCRIPTION
Restore the LE5.jpeg header image directly under the tagline, before the npx install command.