### PR TITLE
chore(release): loop-audit 1.5.2 + loop-init 1.3.1 (Opencode)

### DIFF
--- a/tools/loop-audit/CHANGELOG.md
+++ b/tools/loop-audit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@cobusgreyling/loop-audit` are documented here.
 
+## [1.5.2] - 2026-06-30
+
+### Added
+- Detect verifier agents in `opencode.json` and `opencode.json.example` (maker/checker split for Opencode loops)
+- `--suggest` copy commands for Opencode (`loop-init --tool opencode`)
+
 ## [1.5.0] - 2026-06-30
 
 ### Added

--- a/tools/loop-audit/package.json
+++ b/tools/loop-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobusgreyling/loop-audit",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Loop engineering readiness auditor. Compute Loop Readiness Score (L0-L3), detect activity, and get actionable suggestions. npx @cobusgreyling/loop-audit . --suggest",
   "type": "module",
   "bin": {
@@ -29,6 +29,7 @@
     "claude-code",
     "codex",
     "grok",
+    "opencode",
     "readiness",
     "audit"
   ],

--- a/tools/loop-init/README.md
+++ b/tools/loop-init/README.md
@@ -8,6 +8,7 @@ Scaffold loop engineering starters into your project by pattern and tool.
 
 ```bash
 npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok
+npx @cobusgreyling/loop-init . --pattern daily-triage --tool opencode
 npx @cobusgreyling/loop-init . -p pr-babysitter -t claude
 npx @cobusgreyling/loop-init . -p dependency-sweeper --dry-run
 ```
@@ -41,6 +42,7 @@ Every scaffold also creates:
 - `grok` (default)
 - `claude`
 - `codex`
+- `opencode` — daily-triage ships `minimal-loop-opencode` (`skills/`, `AGENTS.md`, `opencode.json`)
 
 Falls back to Grok starter paths when a per-tool variant is not yet available.
 

--- a/tools/loop-init/package.json
+++ b/tools/loop-init/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cobusgreyling/loop-init",
-  "version": "1.3.0",
-  "description": "Scaffold loop engineering patterns and starters into any project. Supports Grok, Claude Code, Codex and more. npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok",
+  "version": "1.3.1",
+  "description": "Scaffold loop engineering patterns and starters into any project. Supports Grok, Claude Code, Codex, Opencode and more. npx @cobusgreyling/loop-init . --pattern daily-triage --tool opencode",
   "type": "module",
   "bin": {
     "loop-init": "./dist/cli.js"
@@ -31,6 +31,7 @@
     "claude-code",
     "grok",
     "codex",
+    "opencode",
     "github-actions",
     "patterns"
   ],


### PR DESCRIPTION
Version bumps for npm publish after Opencode follow-ups (#100).

**Publish order:** tag `loop-audit-v1.5.2` first, then `loop-init-v1.3.1`.

### loop-audit 1.5.2
- Verifier detection in opencode.json / opencode.json.example
- --suggest Opencode copy commands

### loop-init 1.3.1
- `--tool opencode` scaffolds minimal-loop-opencode
- Bundled starters include Opencode kit