### PR TITLE
fix(ci): skip PR audit comment on fork PRs (403)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,7 +28,8 @@ jobs:
         run: bash scripts/ci-audit-gates.sh
 
       - name: Comment PR with loop readiness score
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
Fork PRs cannot receive workflow comments (403 Resource not accessible by integration). Skip comment step for fork PRs and use continue-on-error as a safety net.

Unblocks community PRs #104 and #105.