### PR TITLE
docs: add Cursor and Windsurf columns to examples coverage (#115)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -82,9 +82,13 @@ opencode run "Run loop-triage. Read STATE.md first. Update High Priority and Wat
 
 See [examples/opencode/daily-triage.md](../examples/opencode/daily-triage.md) for worktree + verifier patterns (L2+).
 
-### Cursor or Windsurf
+### Cursor
 
-No `loop-init --tool cursor` yet — copy skills and state from any starter, then map scheduling to editor Automations or Workflows. See the [Opencode, Cursor & Windsurf appendix](./primitives-matrix.md#appendix-editor-transfer-recipes-opencode-cursor--windsurf) in the primitives matrix.
+No `loop-init --tool cursor` yet — copy skills and state from any starter, then map scheduling to editor Automations. See [examples/cursor/daily-triage.md](../examples/cursor/daily-triage.md).
+
+### Windsurf
+
+No `loop-init --tool windsurf` yet — copy skills and state from any starter, then map scheduling to a Cascade Workflow. See [examples/windsurf/daily-triage.md](../examples/windsurf/daily-triage.md).
 
 ### GitHub Actions only
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ Same patterns, different tools. Skills and state schemas are shared; only schedu
 | Claude Code | [claude-code/](./claude-code/) |
 | Codex App | [codex/](./codex/) |
 | OpenClaw | [openclaw/](./openclaw/) |
+| Cursor | [cursor/](./cursor/) |
+| Windsurf | [windsurf/](./windsurf/) |
 | Opencode | [opencode/](./opencode/) |
 | GitHub Actions | [github-actions/](./github-actions/) |
 | MCP connectors | [mcp/](./mcp/) — config example; reference server in [tools/mcp-server/](../tools/mcp-server/) |
@@ -16,15 +18,15 @@ Start with [primitives-matrix.md](../docs/primitives-matrix.md) to map capabilit
 
 ## Pattern coverage
 
-| Pattern | Grok | Claude | Codex | OpenClaw | Opencode | GH Actions |
-|---------|------|--------|-------|----------|----------|------------|
-| Daily Triage | [grok/daily-triage.md](./grok/daily-triage.md) | [claude-code/daily-triage.md](./claude-code/daily-triage.md) | [codex/daily-triage.md](./codex/daily-triage.md) | [openclaw/daily-triage.md](./openclaw/daily-triage.md) | [opencode/daily-triage.md](./opencode/daily-triage.md) | [github-actions/daily-triage.yml](./github-actions/daily-triage.yml) |
-| PR Babysitter | [grok/pr-babysitter.md](./grok/pr-babysitter.md) | [claude-code/pr-babysitter.md](./claude-code/pr-babysitter.md) | [codex/pr-babysitter.md](./codex/pr-babysitter.md) | [openclaw/pr-babysitter.md](./openclaw/pr-babysitter.md) | [opencode/pr-babysitter.md](./opencode/pr-babysitter.md) | [github-actions/pr-babysitter.yml](./github-actions/pr-babysitter.yml) |
-| CI Sweeper | [grok/ci-sweeper.md](./grok/ci-sweeper.md) | [claude-code/ci-sweeper.md](./claude-code/ci-sweeper.md) | [codex/ci-sweeper.md](./codex/ci-sweeper.md) | [openclaw/ci-sweeper.md](./openclaw/ci-sweeper.md) | [opencode/ci-sweeper.md](./opencode/ci-sweeper.md) | [github-actions/ci-sweeper.yml](./github-actions/ci-sweeper.yml) |
-| Post-Merge Cleanup | [grok/post-merge-cleanup.md](./grok/post-merge-cleanup.md) | [claude-code/post-merge-cleanup.md](./claude-code/post-merge-cleanup.md) | [codex/post-merge-cleanup.md](./codex/post-merge-cleanup.md) | [openclaw/post-merge-cleanup.md](./openclaw/post-merge-cleanup.md) | [opencode/post-merge-cleanup.md](./opencode/post-merge-cleanup.md) | [github-actions/post-merge-cleanup.yml](./github-actions/post-merge-cleanup.yml) |
-| Dependency Sweeper | [grok/dependency-sweeper.md](./grok/dependency-sweeper.md) | [claude-code/dependency-sweeper.md](./claude-code/dependency-sweeper.md) | [codex/dependency-sweeper.md](./codex/dependency-sweeper.md) | [openclaw/dependency-sweeper.md](./openclaw/dependency-sweeper.md) | [opencode/dependency-sweeper.md](./opencode/dependency-sweeper.md) | [github-actions/dependency-sweeper.yml](./github-actions/dependency-sweeper.yml) |
-| Changelog Drafter | [grok/changelog-drafter.md](./grok/changelog-drafter.md) | [claude-code/changelog-drafter.md](./claude-code/changelog-drafter.md) | [codex/changelog-drafter.md](./codex/changelog-drafter.md) | [openclaw/changelog-drafter.md](./openclaw/changelog-drafter.md) | [opencode/changelog-drafter.md](./opencode/changelog-drafter.md) | [github-actions/changelog-drafter.yml](./github-actions/changelog-drafter.yml) |
-| Issue Triage | [grok/issue-triage.md](./grok/issue-triage.md) | [claude-code/issue-triage.md](./claude-code/issue-triage.md) | [codex/issue-triage.md](./codex/issue-triage.md) | [openclaw/issue-triage.md](./openclaw/issue-triage.md) | [opencode/issue-triage.md](./opencode/issue-triage.md) | [github-actions/issue-triage.yml](./github-actions/issue-triage.yml) |
+| Pattern | Grok | Claude | Codex | OpenClaw | Cursor | Windsurf | Opencode | GH Actions |
+|---------|------|--------|-------|----------|--------|----------|----------|------------|
+| Daily Triage | [grok/daily-triage.md](./grok/daily-triage.md) | [claude-code/daily-triage.md](./claude-code/daily-triage.md) | [codex/daily-triage.md](./codex/daily-triage.md) | [openclaw/daily-triage.md](./openclaw/daily-triage.md) | [cursor/daily-triage.md](./cursor/daily-triage.md) | [windsurf/daily-triage.md](./windsurf/daily-triage.md) | [opencode/daily-triage.md](./opencode/daily-triage.md) | [github-actions/daily-triage.yml](./github-actions/daily-triage.yml) |
+| PR Babysitter | [grok/pr-babysitter.md](./grok/pr-babysitter.md) | [claude-code/pr-babysitter.md](./claude-code/pr-babysitter.md) | [codex/pr-babysitter.md](./codex/pr-babysitter.md) | [openclaw/pr-babysitter.md](./openclaw/pr-babysitter.md) | — | — | [opencode/pr-babysitter.md](./opencode/pr-babysitter.md) | [github-actions/pr-babysitter.yml](./github-actions/pr-babysitter.yml) |
+| CI Sweeper | [grok/ci-sweeper.md](./grok/ci-sweeper.md) | [claude-code/ci-sweeper.md](./claude-code/ci-sweeper.md) | [codex/ci-sweeper.md](./codex/ci-sweeper.md) | [openclaw/ci-sweeper.md](./openclaw/ci-sweeper.md) | — | — | [opencode/ci-sweeper.md](./opencode/ci-sweeper.md) | [github-actions/ci-sweeper.yml](./github-actions/ci-sweeper.yml) |
+| Post-Merge Cleanup | [grok/post-merge-cleanup.md](./grok/post-merge-cleanup.md) | [claude-code/post-merge-cleanup.md](./claude-code/post-merge-cleanup.md) | [codex/post-merge-cleanup.md](./codex/post-merge-cleanup.md) | [openclaw/post-merge-cleanup.md](./openclaw/post-merge-cleanup.md) | — | — | [opencode/post-merge-cleanup.md](./opencode/post-merge-cleanup.md) | [github-actions/post-merge-cleanup.yml](./github-actions/post-merge-cleanup.yml) |
+| Dependency Sweeper | [grok/dependency-sweeper.md](./grok/dependency-sweeper.md) | [claude-code/dependency-sweeper.md](./claude-code/dependency-sweeper.md) | [codex/dependency-sweeper.md](./codex/dependency-sweeper.md) | [openclaw/dependency-sweeper.md](./openclaw/dependency-sweeper.md) | — | — | [opencode/dependency-sweeper.md](./opencode/dependency-sweeper.md) | [github-actions/dependency-sweeper.yml](./github-actions/dependency-sweeper.yml) |
+| Changelog Drafter | [grok/changelog-drafter.md](./grok/changelog-drafter.md) | [claude-code/changelog-drafter.md](./claude-code/changelog-drafter.md) | [codex/changelog-drafter.md](./codex/changelog-drafter.md) | [openclaw/changelog-drafter.md](./openclaw/changelog-drafter.md) | — | — | [opencode/changelog-drafter.md](./opencode/changelog-drafter.md) | [github-actions/changelog-drafter.yml](./github-actions/changelog-drafter.yml) |
+| Issue Triage | [grok/issue-triage.md](./grok/issue-triage.md) | [claude-code/issue-triage.md](./claude-code/issue-triage.md) | [codex/issue-triage.md](./codex/issue-triage.md) | [openclaw/issue-triage.md](./openclaw/issue-triage.md) | — | — | [opencode/issue-triage.md](./opencode/issue-triage.md) | [github-actions/issue-triage.yml](./github-actions/issue-triage.yml) |
 
 L2 patterns ship multi-tool skills inside one starter folder — see `starters/<pattern>/`.
 

--- a/examples/cursor/README.md
+++ b/examples/cursor/README.md
@@ -1,0 +1,14 @@
+# Cursor Examples
+
+Copy-pasteable loop patterns for Cursor, using **Automations** (cloud cron) or manual Agent chat for scheduling and `.cursor/skills/` + `.cursor/rules/` for persistent skill context.
+
+| Example | Cadence | Risk | File |
+|---|---|---|---|
+| Daily Triage | 1d–2h (Automation or manual) | Low | [daily-triage.md](daily-triage.md) |
+
+No `loop-init --tool cursor` yet — copy `SKILL.md` + `STATE.md` from any starter (e.g. `starters/minimal-loop`), then follow the example to wire scheduling.
+
+Audit after copying:
+```bash
+npx @cobusgreyling/loop-audit . --suggest
+```

--- a/examples/cursor/daily-triage.md
+++ b/examples/cursor/daily-triage.md
@@ -1,0 +1,45 @@
+# Daily Triage — Cursor (Automations / Agent)
+
+This is a practical, copy-pasteable example of a morning triage loop using Cursor.
+
+Cursor has no native `/loop` scheduler (unlike Grok or Claude Code). Map the loop to a **Cloud Automation** (cron) or a recurring **Agent** prompt on cadence.
+
+## Automation prompt (week one — report only)
+
+In Cursor → Automations, create a daily job with a prompt like:
+
+```text
+Run the loop-triage skill on the current project.
+Append high-priority items to STATE.md (High Priority + Watch List only).
+Do not open PRs or modify source code in week one.
+Flag anything ambiguous or high-risk for human review in STATE.md.
+```
+
+Or invoke manually in Agent chat with the same prompt on your chosen cadence.
+
+## Progression
+
+- **Week one — report only.** Just append to `STATE.md`. Read it yourself daily before trusting the loop.
+- **Add "act on obvious small wins."** Extend the automation to draft minimal fixes in an isolated worktree.
+- **Add connectors.** Wire PR creation / ticket comments via GitHub MCP (read-only discovery first).
+- **Add self-cleanup.** Remove the automation trigger when there is nothing left to watch.
+
+## Requirements
+
+- `STATE.md` in the repo root (committed or shared location)
+- The `loop-triage` skill in `.cursor/skills/loop-triage/SKILL.md` (copy from `templates/SKILL.md.loop-triage`)
+- Optional always-on triage rules in `.cursor/rules/`
+- Cloud Automation for unattended cadence — manual Agent chat works for week one
+
+## Example STATE.md
+
+```markdown
+# Loop State — Project X
+Last run: 2026-07-02 08:15 UTC
+
+## High Priority (loop is acting or waiting on human)
+- [ ] #1241 — flaky test in auth flow (CI red on main)
+      Loop action: report only (week one). Needs human triage.
+```
+
+See the [primitives matrix](../../docs/primitives-matrix.md#appendix-editor-transfer-recipes-opencode-cursor--windsurf) for how Cursor maps to the same six-part loop shape.

--- a/examples/windsurf/README.md
+++ b/examples/windsurf/README.md
@@ -1,0 +1,14 @@
+# Windsurf Examples
+
+Copy-pasteable loop patterns for Windsurf, using Cascade Workflows for scheduling and `.windsurf/rules/` for persistent skill context.
+
+| Example | Cadence | Risk | File |
+|---|---|---|---|
+| Daily Triage | 1d–2h (manual `/daily-triage`) | Low | [daily-triage.md](daily-triage.md) |
+
+No `loop-init --tool windsurf` yet — copy `SKILL.md` + `STATE.md` from any starter (e.g. `starters/minimal-loop`), then follow the example to wire a Cascade Workflow.
+
+Audit after copying:
+```bash
+npx @cobusgreyling/loop-audit . --suggest
+```

--- a/examples/windsurf/daily-triage.md
+++ b/examples/windsurf/daily-triage.md
@@ -1,0 +1,48 @@
+# Daily Triage — Windsurf (Cascade Workflows)
+
+This is a practical, copy-pasteable example of a morning triage loop using Windsurf's Cascade.
+
+Windsurf has no native `/loop` scheduler (unlike Grok or Claude Code). Map the loop to a **Cascade Workflow** (`.windsurf/workflows/daily-triage.md`), invoked manually via `/daily-triage` in Cascade chat.
+
+## Workflow
+
+Create `.windsurf/workflows/daily-triage.md`:
+
+```markdown
+# Daily Triage
+
+**Description:** Morning triage — report only, no auto-fix.
+
+1. Run the loop-triage skill on the current project.
+2. Append high-priority items to `STATE.md` (High Priority + Watch List only).
+3. Do not open PRs or modify source code in week one.
+4. Flag anything ambiguous or high-risk for human review in `STATE.md`.
+```
+
+Invoke in Cascade with `/daily-triage`. For unattended cadence, use an external trigger (GitHub Actions cron, `launchd`/`cron`) that reminds you to run the workflow — Windsurf workflows are invoke-based, not self-scheduling.
+
+## Progression
+
+- **Week one — report only.** Just append to `STATE.md`. Read it yourself daily before trusting the loop.
+- **Add "act on obvious small wins."** Extend the workflow to draft minimal fixes using the `minimal-fix` skill in an isolated worktree.
+- **Add connectors.** Wire PR creation / ticket comments via MCP once confident.
+- **Add self-cleanup.** Remove the workflow trigger when there is nothing left to watch.
+
+## Requirements
+
+- `STATE.md` in the repo root (committed or shared location)
+- The `loop-triage` skill in `.windsurf/rules/loop-triage.md` (copy from `templates/SKILL.md.loop-triage`)
+- Manual `/daily-triage` invoke for week one; external scheduler optional for reminders
+
+## Example STATE.md
+
+```markdown
+# Loop State — Project X
+Last run: 2026-07-02 08:15 UTC
+
+## High Priority (loop is acting or waiting on human)
+- [ ] #1241 — flaky test in auth flow (CI red on main)
+      Loop action: report only (week one). Needs human triage.
+```
+
+See the [primitives matrix](../../docs/primitives-matrix.md#appendix-editor-transfer-recipes-opencode-cursor--windsurf) for how Windsurf's workflow model maps to the same six-part loop shape.


### PR DESCRIPTION
## Summary
Adds Cursor and Windsurf to the examples index and pattern coverage table. Includes daily-triage examples with correct Windsurf workflow format (single Markdown file, `/daily-triage` invoke).

## Changes
- [x] Doc / example improvement
- [x] Cursor + Windsurf columns in `examples/README.md` pattern table
- [x] `examples/cursor/` and `examples/windsurf/` directories
- [x] QUICKSTART split for Cursor vs Windsurf with example links

Fixes #115. Also delivers the cursor daily-triage example (#113) and a maintainer-corrected windsurf example (complements #126).

## Checklist
- [x] Links work from README indexes
- [x] No secrets
- [x] Week-one report-only cadence documented