### PR TITLE
fix(loop-sync): honor json output flag

### DIFF
--- a/tools/loop-sync/dist/cli.js
+++ b/tools/loop-sync/dist/cli.js
@@ -27,7 +27,7 @@ function parseArgs(argv) {
         else if (!a.startsWith('-'))
             targetDir = a;
     }
-    return { targetDir, autoFix, dryRun, verbose, help };
+    return { targetDir, autoFix, dryRun, verbose, help, json };
 }
 async function main() {
     const args = parseArgs(process.argv.slice(2));

--- a/tools/loop-sync/src/cli.ts
+++ b/tools/loop-sync/src/cli.ts
@@ -25,7 +25,7 @@ function parseArgs(argv: string[]): SyncOptions {
     else if (!a.startsWith('-')) targetDir = a;
   }
 
-  return { targetDir, autoFix, dryRun, verbose, help };
+  return { targetDir, autoFix, dryRun, verbose, help, json };
 }
 
 async function main() {

--- a/tools/loop-sync/test/sync.test.mjs
+++ b/tools/loop-sync/test/sync.test.mjs
@@ -2,9 +2,13 @@ import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { runSync, formatReport } from '../dist/sync.js';
 
 const testDir = path.join(process.cwd(), '.test-tmp');
+const exec = promisify(execFile);
+const CLI = path.resolve('dist/cli.js');
 
 async function setupTestDir() {
   await mkdir(testDir, { recursive: true });
@@ -111,5 +115,26 @@ describe('formatReport', () => {
 
     assert.match(formatted, /AGENTS\.md/);
     assert.match(formatted, /missing/i);
+  });
+});
+
+describe('cli', () => {
+  beforeEach(setupTestDir);
+  afterEach(cleanupTestDir);
+
+  test('emits JSON when --json is provided', async () => {
+    let stdout;
+    try {
+      ({ stdout } = await exec('node', [CLI, testDir, '--json']));
+    } catch (err) {
+      stdout = err.stdout;
+      assert.equal(err.code, 2);
+    }
+    const report = JSON.parse(stdout);
+
+    assert.equal(typeof report.score, 'number');
+    assert.ok(['healthy', 'warning', 'critical'].includes(report.level));
+    assert.ok(Array.isArray(report.issues));
+    assert.ok(Array.isArray(report.suggestions));
   });
 });


### PR DESCRIPTION
## Summary
Make `loop-sync --json` emit the machine-readable drift report it documents, so CI and agent loops can parse the result reliably.

## Changes
- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example improvement
- [x] Tool change (`loop-sync`)
- [ ] Story (includes real failure or surprise + lesson)

## Details
`loop-sync` already parsed `--json`, but `parseArgs` did not return the parsed `json` flag. As a result, users running `loop-sync <target> --json` still received the human-readable report.

This fixes the CLI contract by carrying the parsed flag through to `main`, and adds a CLI-level regression test that parses stdout as JSON even when `loop-sync` exits with the existing warning code.

## Checklist (from CONTRIBUTING)
- [ ] All required sections present for patterns
- [ ] Links work from README, patterns/README, starters/README, docs/index
- [x] No secrets, tokens, internal company URLs
- [ ] `STATE.md*` examples use `.example` suffix
- [ ] Safety-related content references `docs/safety.md`
- [x] Ran `node tools/loop-audit/dist/cli.js .` through `scripts/ci-audit-gates.sh`

## Testing / Dogfood
- [x] `cd tools/loop-sync && npm test`
- [x] `bash scripts/ci-validate-gates.sh`
- [x] `bash scripts/ci-audit-gates.sh`
- [x] `git diff --check`

## Screenshots / Examples (if UI or command output)

Before this change, `loop-sync --json` emitted the human-readable `Loop Sync Report`. The added regression test now executes the built CLI with `--json` and verifies stdout parses as JSON.

---

*This template enforces the high bar this reference is known for.*