### PR TITLE
fix(ci): grant issues:write to welcome workflow for fork PR comments

### DIFF
--- a/.github/workflows/welcome-contributors.yml
+++ b/.github/workflows/welcome-contributors.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
 
 permissions:
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
The welcome-contributors workflow posts comments via the Issues API. Fork PR runs were failing with 403 because only `pull-requests: write` was declared — `issues: write` is also required.

Unblocks welcome checks on contributor PRs like #141.