### PR TITLE
fix(loop-context): reject invalid numeric limit flags

### DIFF
--- a/tools/loop-context/dist/cli.js
+++ b/tools/loop-context/dist/cli.js
@@ -1,6 +1,17 @@
 #!/usr/bin/env node
 import { readFile } from 'node:fs/promises';
 import { buildContextInjection, checkCircuitBreaker, pruneLedger, summarizeAttempts, DEFAULT_BREAKER, DEFAULT_PRUNE, } from './context-manager.js';
+/** Reject NaN/0/floats so a bad flag cannot silently disable the breaker. */
+function parsePositiveIntFlag(raw, flag) {
+    if (raw === undefined || raw === '') {
+        throw new Error(`${flag} requires a positive integer value.`);
+    }
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n < 1) {
+        throw new Error(`${flag} must be a positive integer; got "${raw}".`);
+    }
+    return n;
+}
 function parseArgs(argv) {
     const breaker = { ...DEFAULT_BREAKER };
     const prune = { ...DEFAULT_PRUNE };
@@ -26,17 +37,17 @@ function parseArgs(argv) {
         else if (a === '--json')
             json = true;
         else if (a === '--max-iterations')
-            breaker.maxIterations = Number(argv[++i]);
+            breaker.maxIterations = parsePositiveIntFlag(argv[++i], '--max-iterations');
         else if (a === '--stagnation')
-            breaker.stagnationThreshold = Number(argv[++i]);
+            breaker.stagnationThreshold = parsePositiveIntFlag(argv[++i], '--stagnation');
         else if (a === '--no-progress')
-            breaker.noProgressThreshold = Number(argv[++i]);
+            breaker.noProgressThreshold = parsePositiveIntFlag(argv[++i], '--no-progress');
         else if (a === '--token-budget')
-            breaker.tokenBudget = Number(argv[++i]);
+            breaker.tokenBudget = parsePositiveIntFlag(argv[++i], '--token-budget');
         else if (a === '--window')
-            prune.window = Number(argv[++i]);
+            prune.window = parsePositiveIntFlag(argv[++i], '--window');
         else if (a === '--max-trace-lines')
-            prune.maxTraceLines = Number(argv[++i]);
+            prune.maxTraceLines = parsePositiveIntFlag(argv[++i], '--max-trace-lines');
     }
     return { help: false, op, ledger, json, breaker, prune };
 }

--- a/tools/loop-context/package.json
+++ b/tools/loop-context/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsc && chmod +x dist/cli.js",
-    "test": "npm run build && node --test test/context-manager.test.mjs",
+    "test": "npm run build && node --test test/*.test.mjs",
     "prepublishOnly": "npm test",
     "start": "node dist/cli.js"
   },

--- a/tools/loop-context/src/cli.ts
+++ b/tools/loop-context/src/cli.ts
@@ -23,6 +23,18 @@ interface Args {
   prune: PruneConfig;
 }
 
+/** Reject NaN/0/floats so a bad flag cannot silently disable the breaker. */
+function parsePositiveIntFlag(raw: string | undefined, flag: string): number {
+  if (raw === undefined || raw === '') {
+    throw new Error(`${flag} requires a positive integer value.`);
+  }
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`${flag} must be a positive integer; got "${raw}".`);
+  }
+  return n;
+}
+
 function parseArgs(argv: string[]): Args {
   const breaker: CircuitBreakerConfig = { ...DEFAULT_BREAKER };
   const prune: PruneConfig = { ...DEFAULT_PRUNE };
@@ -40,12 +52,12 @@ function parseArgs(argv: string[]): Args {
     else if (a === '--summary') op = 'summary';
     else if (a === '--status') op = 'status';
     else if (a === '--json') json = true;
-    else if (a === '--max-iterations') breaker.maxIterations = Number(argv[++i]);
-    else if (a === '--stagnation') breaker.stagnationThreshold = Number(argv[++i]);
-    else if (a === '--no-progress') breaker.noProgressThreshold = Number(argv[++i]);
-    else if (a === '--token-budget') breaker.tokenBudget = Number(argv[++i]);
-    else if (a === '--window') prune.window = Number(argv[++i]);
-    else if (a === '--max-trace-lines') prune.maxTraceLines = Number(argv[++i]);
+    else if (a === '--max-iterations') breaker.maxIterations = parsePositiveIntFlag(argv[++i], '--max-iterations');
+    else if (a === '--stagnation') breaker.stagnationThreshold = parsePositiveIntFlag(argv[++i], '--stagnation');
+    else if (a === '--no-progress') breaker.noProgressThreshold = parsePositiveIntFlag(argv[++i], '--no-progress');
+    else if (a === '--token-budget') breaker.tokenBudget = parsePositiveIntFlag(argv[++i], '--token-budget');
+    else if (a === '--window') prune.window = parsePositiveIntFlag(argv[++i], '--window');
+    else if (a === '--max-trace-lines') prune.maxTraceLines = parsePositiveIntFlag(argv[++i], '--max-trace-lines');
   }
 
   return { help: false, op, ledger, json, breaker, prune };

--- a/tools/loop-context/test/cli.test.mjs
+++ b/tools/loop-context/test/cli.test.mjs
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), '../dist/cli.js');
+
+const stagnationLedger = JSON.stringify({
+  goal: 'x',
+  attempts: [
+    { iteration: 1, action: 'a', outcome: 'failure', error: 'boom' },
+    { iteration: 2, action: 'a', outcome: 'failure', error: 'boom' },
+    { iteration: 3, action: 'a', outcome: 'failure', error: 'boom' },
+  ],
+});
+
+function runCli(args, input = stagnationLedger) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    input,
+    encoding: 'utf8',
+  });
+}
+
+test('cli --check trips stagnation with default threshold', () => {
+  const r = runCli(['--check', '--json']);
+  assert.equal(r.status, 2);
+  const decision = JSON.parse(r.stdout);
+  assert.equal(decision.trigger, 'stagnation');
+});
+
+test('cli rejects invalid --stagnation values before running the breaker', () => {
+  const r = runCli(['--check', '--stagnation', 'nope', '--json']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /--stagnation must be a positive integer/);
+});
+
+test('cli rejects invalid --no-progress values', () => {
+  const r = runCli(['--check', '--no-progress', '0', '--json']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /--no-progress must be a positive integer/);
+});
+
+test('cli rejects invalid --max-iterations values', () => {
+  const r = runCli(['--check', '--max-iterations', '1.5', '--json']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /--max-iterations must be a positive integer/);
+});
+
+test('cli rejects missing numeric flag values', () => {
+  const r = runCli(['--check', '--stagnation']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /--stagnation requires a positive integer value/);
+});


### PR DESCRIPTION
Fixes #139

## Problem
Invalid numeric limit flags (`--stagnation nope`, `--no-progress 0`, etc.) were parsed with `Number()` and became `NaN`, which silently disabled the circuit breaker instead of failing closed.

## Fix
- Validate all numeric CLI flags as positive integers before running any operation
- Exit **1** with a clear usage/config error when a flag value is missing or invalid
- Add CLI integration tests covering the reported repro

## Repro (now fails as expected)
\`\`\`bash
printf '%s' '{"goal":"x","attempts":[...]}' | node tools/loop-context/dist/cli.js --check --stagnation nope --json
# loop-context failed: --stagnation must be a positive integer; got "nope".
# exit 1
\`\`\`