### PR TITLE
fix: welcome-contributors permissions + loop-cost openclaw/opencode

### DIFF
--- a/.github/workflows/welcome-contributors.yml
+++ b/.github/workflows/welcome-contributors.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   welcome:

--- a/tools/loop-cost/registry.json
+++ b/tools/loop-cost/registry.json
@@ -11,6 +11,8 @@
         "grok",
         "claude-code",
         "codex",
+        "openclaw",
+        "opencode",
         "github-actions"
       ],
       "skills": [
@@ -54,6 +56,8 @@
         "grok",
         "claude-code",
         "codex",
+        "openclaw",
+        "opencode",
         "github-actions"
       ],
       "skills": [
@@ -92,6 +96,8 @@
         "grok",
         "claude-code",
         "codex",
+        "openclaw",
+        "opencode",
         "github-actions"
       ],
       "skills": [
@@ -133,6 +139,8 @@
         "grok",
         "claude-code",
         "codex",
+        "openclaw",
+        "opencode",
         "github-actions"
       ],
       "skills": [
@@ -173,6 +181,8 @@
         "grok",
         "claude-code",
         "codex",
+        "openclaw",
+        "opencode",
         "github-actions"
       ],
       "skills": [
@@ -216,6 +226,8 @@
         "grok",
         "claude-code",
         "codex",
+        "openclaw",
+        "opencode",
         "github-actions"
       ],
       "skills": [
@@ -259,6 +271,8 @@
         "grok",
         "claude-code",
         "codex",
+        "openclaw",
+        "opencode",
         "github-actions"
       ],
       "skills": [


### PR DESCRIPTION
Fixes welcome-contributors workflow failing with 'Resource not accessible by integration' on docs/example PRs (#156).

Also adds openclaw and opencode to loop-cost pattern tool lists (leftover from coverage work).