### PR TITLE
chore: refresh contributor backlog (#159-163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For developers using Grok, Claude Code, Codex, Cursor, and other AI coding agent
 | [loop-mcp-server](tools/mcp-server/) | MCP runtime lookup for patterns, skills, state — `node tools/mcp-server/dist/index.js` (repo v1; npm pending) |
 | [Goal Engineering](https://github.com/cobusgreyling/goal-engineering) | **Companion:** loops discover, goals finish — `/goal` + [stack cookbook](https://github.com/cobusgreyling/goal-engineering/blob/main/docs/stack-cookbook.md) (`npx @cobusgreyling/goal doctor .`) |
 | [Stories](stories/) | Real wins and honest failures |
-| [Contributor quickstart](https://github.com/cobusgreyling/loop-engineering/discussions/123) | **Help wanted:** 11 scoped `good first issues` — comment *I'll take this* to get assigned |
+| [Contributor quickstart](https://github.com/cobusgreyling/loop-engineering/discussions/123) | **Help wanted:** 12 scoped `good first issues` — comment *I'll take this* to get assigned |
 | [Community update](https://github.com/cobusgreyling/loop-engineering/discussions/145) | **July 4:** 5.5k stars, traffic sources, contributor merges |
 | [Prior release notes](https://github.com/cobusgreyling/loop-engineering/discussions/89) | v1.5.0 — loop-sync, constraints, MCP server |
 | [Add your project](https://github.com/cobusgreyling/loop-engineering/discussions/92) | **Pinned:** Loop Ready badge + adopters list |

--- a/scripts/create-good-first-issues.sh
+++ b/scripts/create-good-first-issues.sh
@@ -29,6 +29,11 @@ create_issue "Share a PR Babysitter failure story" "good first issue,story" "$BO
 create_issue "Add your project to the adopters list" "good first issue,docs" "$BODY_DIR/adopters-row.md"
 create_issue "Clarify loop-init --tool values in QUICKSTART cheat sheet" "good first issue,docs" "$BODY_DIR/quickstart-tool-values.md"
 create_issue "Add loop-triage constraints example for Cursor" "good first issue,docs" "$BODY_DIR/cursor-constraints.md"
+create_issue "Add Hermes to examples README copy-paste starters table" "good first issue,docs" "$BODY_DIR/hermes-copy-paste-starters.md"
+create_issue "Add Hermes section to QUICKSTART" "good first issue,docs" "$BODY_DIR/hermes-quickstart.md"
+create_issue "Add examples/hermes/README.md index" "good first issue,docs" "$BODY_DIR/hermes-readme-index.md"
+create_issue "Add Windsurf PR Babysitter example doc" "good first issue,docs" "$BODY_DIR/windsurf-pr-babysitter-example.md"
+create_issue "Share a Post-Merge Cleanup production story" "good first issue,story" "$BODY_DIR/post-merge-cleanup-story.md"
 
 echo "Done. Open backlog:"
 echo "https://github.com/cobusgreyling/loop-engineering/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22"

--- a/scripts/issue-bodies/hermes-copy-paste-starters.md
+++ b/scripts/issue-bodies/hermes-copy-paste-starters.md
@@ -1,0 +1,12 @@
+## Goal
+Add **Hermes Agent** to the copy-paste starters table in `examples/README.md` so CLI schedulers find the bridge from the examples index.
+
+## Files
+- `examples/README.md`
+
+## Acceptance criteria
+- [ ] Add Hermes row to the **Copy-paste starters** table (at least Daily Triage — link `examples/hermes/daily-triage.md`)
+- [ ] Use `—` or honest notes for L2 patterns without Hermes examples yet
+- [ ] Keep table formatting consistent with OpenClaw / Opencode rows
+
+**Estimated time:** ~15 minutes

--- a/scripts/issue-bodies/hermes-quickstart.md
+++ b/scripts/issue-bodies/hermes-quickstart.md
@@ -1,0 +1,13 @@
+## Goal
+Add a **Hermes Agent** subsection to the Quickstart run instructions so newcomers landing from the Hermes column in the primitives matrix have a copy-paste path.
+
+## Files
+- `docs/QUICKSTART.md`
+
+## Acceptance criteria
+- [ ] New `### Hermes` block in section 5 (same style as Cursor / Windsurf / OpenClaw)
+- [ ] Link `examples/hermes/daily-triage.md` and note `hermes cron` + `loop-triage` skill install
+- [ ] Week-one report-only rule preserved
+- [ ] No claim that `loop-init --tool hermes` exists yet
+
+**Estimated time:** ~15 minutes

--- a/scripts/issue-bodies/hermes-readme-index.md
+++ b/scripts/issue-bodies/hermes-readme-index.md
@@ -1,0 +1,13 @@
+## Goal
+Add `examples/hermes/README.md` so Hermes examples have the same index treatment as Cursor, Windsurf, and OpenClaw.
+
+## Files
+- `examples/hermes/README.md` (new)
+
+## Acceptance criteria
+- [ ] Table of available examples (at least Daily Triage today)
+- [ ] One paragraph on `hermes cron` + skills + `STATE.md`
+- [ ] Link to `examples/README.md` pattern matrix and `docs/primitives-matrix.md` Hermes column
+- [ ] Note that `loop-init --tool hermes` is not scaffolded yet
+
+**Estimated time:** ~10 minutes

--- a/scripts/issue-bodies/post-merge-cleanup-story.md
+++ b/scripts/issue-bodies/post-merge-cleanup-story.md
@@ -1,0 +1,14 @@
+## Goal
+Share a real **Post-Merge Cleanup** production story — win or honest failure — to help others calibrate tech-debt scanning loops.
+
+## Files
+- New file under `stories/` (follow `stories/TEMPLATE.md` or an existing story)
+- Update `stories/README.md` index row
+
+## Acceptance criteria
+- [ ] Which tool and cadence you used
+- [ ] What the loop caught (or missed) in the first week
+- [ ] Kill switch, verifier, or human gate you relied on
+- [ ] One lesson for the next team trying Post-Merge Cleanup
+
+**Estimated time:** ~45 minutes

--- a/scripts/issue-bodies/windsurf-pr-babysitter-example.md
+++ b/scripts/issue-bodies/windsurf-pr-babysitter-example.md
@@ -1,0 +1,14 @@
+## Goal
+Add a **Windsurf PR Babysitter** example doc — the pattern coverage table has a gap for Windsurf L2 patterns (Cursor landed in #156).
+
+## Files
+- `examples/windsurf/pr-babysitter.md` (new)
+- `examples/windsurf/README.md` (add row)
+- `examples/README.md` (fill the `—` in PR Babysitter × Windsurf cell)
+
+## Acceptance criteria
+- [ ] Mirror the structure of `examples/cursor/pr-babysitter.md` (Cascade Workflow or manual invoke, week-one report-only, verifier split)
+- [ ] Honest note where Windsurf has no native cron — pair with GitHub Action or external scheduler if needed
+- [ ] Link to `starters/pr-babysitter/` skills and `pr-babysitter-state.md`
+
+**Estimated time:** ~30 minutes


### PR DESCRIPTION
Backs the July 5 contributor funnel refresh:

- README: good-first-issue count **12**
- Issue body templates + bootstrap script entries for #159–#163
- Discussion #123 updated separately