### PR TITLE
feat(loop-guard): size the token budget from loop-cost per pattern

### DIFF
--- a/templates/SKILL.md.loop-guard
+++ b/templates/SKILL.md.loop-guard
@@ -18,11 +18,15 @@ The breaker needs no LLM call, so it is cheap enough to run on every iteration.
 
 ## The ledger
 
-`loop-ledger.json` records the loop's goal and one entry per attempt:
+`loop-ledger.json` records the loop's goal, its pattern/level, and one entry per
+attempt:
 
 ```json
-{ "goal": "Get failing CI green", "attempts": [] }
+{ "goal": "Get failing CI green", "pattern": "ci-sweeper", "level": "L2", "attempts": [] }
 ```
+
+`pattern` and `level` are seeded by `loop-init`; the breaker ignores them but the
+budget step below reads them to size `--token-budget` from real cost data.
 
 After every iteration, append what you just tried:
 
@@ -34,12 +38,30 @@ After every iteration, append what you just tried:
 `outcome` is `success | failure | noop`. Always include `error` on failures —
 that is how the breaker detects a repeated (stagnant) failure.
 
+## Size the token budget from the pattern (once per run)
+
+Don't hand-type a token cap — derive it from the pattern's realistic per-run
+cost so the breaker trips on genuine cost blowup, not a made-up number.
+[`loop-cost`](https://github.com/cobusgreyling/loop-engineering/tree/main/tools/loop-cost)
+already computes this from `patterns/registry.yaml`; read the loop's `pattern`
+and `level` straight from the ledger:
+
+```bash
+# Substitute the ledger's own pattern/level (here: ci-sweeper / L2).
+BUDGET=$(npx @cobusgreyling/loop-cost --pattern ci-sweeper --level L2 --json \
+  | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>process.stdout.write(String(JSON.parse(d).scenarios.realistic.tokensPerRun)))')
+```
+
+`scenarios.realistic.tokensPerRun` is a rounded integer, so it feeds
+`--token-budget` directly. The two tools stay independent — this is shell
+wiring, not a code dependency.
+
 ## Before each iteration
 
 1. Append the previous attempt to `loop-ledger.json`.
-2. Run the breaker:
+2. Run the breaker with the resolved budget:
    ```bash
-   npx @cobusgreyling/loop-context --check --ledger loop-ledger.json
+   npx @cobusgreyling/loop-context --check --ledger loop-ledger.json --token-budget "$BUDGET"
    ```
 3. Act on the exit code:
    - **0** → continue. Optionally trim the next prompt first:
@@ -68,4 +90,5 @@ that is how the breaker detects a repeated (stagnant) failure.
 - `minimal-fix` / `ci-triage` — record each attempt's outcome + error in the ledger.
 - `loop-verifier` — a verifier rejection is a `failure`; log it so repeats trip the breaker.
 - `loop-constraints` — honors "escalate after N attempts"; this skill makes it mechanical.
-- `loop-budget` — `--token-budget` mirrors the daily cap in loop-budget.md.
+- `loop-budget` — the per-run `--token-budget` here comes from loop-cost's
+  realistic estimate; loop-budget.md still governs the *daily* cap across runs.

--- a/tools/loop-cost/README.md
+++ b/tools/loop-cost/README.md
@@ -41,4 +41,18 @@ Each estimate includes:
 
 Pair with `loop-budget.md` (scaffolded by `loop-init`) and `loop-audit` cost observability checks.
 
+## Feed the circuit breaker
+
+`--json` output resolves a realistic per-run token cap for
+[`loop-context`](../loop-context)'s breaker, so `--token-budget` reflects real
+pattern cost instead of a hand-typed guess (the `loop-guard` skill wires this):
+
+```bash
+BUDGET=$(npx @cobusgreyling/loop-cost --pattern ci-sweeper --level L2 --json \
+  | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>process.stdout.write(String(JSON.parse(d).scenarios.realistic.tokensPerRun)))')
+npx @cobusgreyling/loop-context --check --ledger loop-ledger.json --token-budget "$BUDGET"
+```
+
+The tools stay independent — no runtime dependency, just shell wiring.
+
 See [docs/operating-loops.md](../../docs/operating-loops.md).

--- a/tools/loop-init/README.md
+++ b/tools/loop-init/README.md
@@ -34,9 +34,9 @@ L2 patterns (`ci-sweeper`, `dependency-sweeper`) also copy `minimal-fix` and `lo
 Fix-capable patterns (`pr-babysitter`, `ci-sweeper`, `dependency-sweeper`, `post-merge-cleanup`) also get a **circuit breaker**:
 
 - `loop-guard` skill — logs each attempt to `loop-ledger.json` and runs [`loop-context`](../loop-context) `--check` before retrying
-- `loop-ledger.json` — seeded with the pattern's goal and an empty `attempts` array
+- `loop-ledger.json` — seeded with the pattern's goal, its `pattern`/`level`, and an empty `attempts` array
 
-The breaker escalates (same error N× in a row, too many consecutive failures, token budget, or iteration cap) instead of looping in vain. Report-only patterns skip it.
+The ledger's `pattern`/`level` let `loop-guard` size the breaker's `--token-budget` from [`loop-cost`](../loop-cost)'s realistic per-run estimate instead of a hand-typed number. The breaker escalates (same error N× in a row, too many consecutive failures, token budget, or iteration cap) instead of looping in vain. Report-only patterns skip it.
 
 Every scaffold also creates:
 

--- a/tools/loop-init/dist/cli.js
+++ b/tools/loop-init/dist/cli.js
@@ -153,6 +153,22 @@ const LEDGER_GOAL = {
     'issue-triage': 'Triage the open issue queue',
 };
 /**
+ * Readiness level seeded into loop-ledger.json so the loop-guard skill can
+ * resolve a realistic per-run token budget from `loop-cost --json` instead of a
+ * hand-typed number. Fix-capable loops draft changes with a verifier (a human
+ * still merges), so L2 is the right default; tune it in the ledger if a loop
+ * runs unattended (L3) or report-only (L1).
+ */
+const LEDGER_LEVEL = {
+    'daily-triage': 'L1',
+    'pr-babysitter': 'L2',
+    'ci-sweeper': 'L2',
+    'dependency-sweeper': 'L2',
+    'post-merge-cleanup': 'L2',
+    'changelog-drafter': 'L1',
+    'issue-triage': 'L1',
+};
+/**
  * Fix-capable loops retry actions, so they need a circuit breaker: scaffold the
  * loop-guard skill plus a seeded loop-ledger.json wired to `loop-context`.
  * Report-only patterns (daily-triage, issue-triage, changelog-drafter) don't
@@ -165,7 +181,7 @@ async function scaffoldCircuitBreaker(pattern, tool, targetDir, templatesRoot, d
     const ledgerPath = path.join(targetDir, 'loop-ledger.json');
     if (await exists(ledgerPath))
         return;
-    const seed = `${JSON.stringify({ goal: LEDGER_GOAL[pattern], attempts: [] }, null, 2)}\n`;
+    const seed = `${JSON.stringify({ goal: LEDGER_GOAL[pattern], pattern, level: LEDGER_LEVEL[pattern], attempts: [] }, null, 2)}\n`;
     if (dryRun) {
         console.log(`  would write: ${ledgerPath}`);
         return;

--- a/tools/loop-init/src/cli.ts
+++ b/tools/loop-init/src/cli.ts
@@ -196,6 +196,23 @@ const LEDGER_GOAL: Record<Pattern, string> = {
 };
 
 /**
+ * Readiness level seeded into loop-ledger.json so the loop-guard skill can
+ * resolve a realistic per-run token budget from `loop-cost --json` instead of a
+ * hand-typed number. Fix-capable loops draft changes with a verifier (a human
+ * still merges), so L2 is the right default; tune it in the ledger if a loop
+ * runs unattended (L3) or report-only (L1).
+ */
+const LEDGER_LEVEL: Record<Pattern, string> = {
+  'daily-triage': 'L1',
+  'pr-babysitter': 'L2',
+  'ci-sweeper': 'L2',
+  'dependency-sweeper': 'L2',
+  'post-merge-cleanup': 'L2',
+  'changelog-drafter': 'L1',
+  'issue-triage': 'L1',
+};
+
+/**
  * Fix-capable loops retry actions, so they need a circuit breaker: scaffold the
  * loop-guard skill plus a seeded loop-ledger.json wired to `loop-context`.
  * Report-only patterns (daily-triage, issue-triage, changelog-drafter) don't
@@ -214,7 +231,11 @@ async function scaffoldCircuitBreaker(
 
   const ledgerPath = path.join(targetDir, 'loop-ledger.json');
   if (await exists(ledgerPath)) return;
-  const seed = `${JSON.stringify({ goal: LEDGER_GOAL[pattern], attempts: [] }, null, 2)}\n`;
+  const seed = `${JSON.stringify(
+    { goal: LEDGER_GOAL[pattern], pattern, level: LEDGER_LEVEL[pattern], attempts: [] },
+    null,
+    2,
+  )}\n`;
   if (dryRun) {
     console.log(`  would write: ${ledgerPath}`);
     return;

--- a/tools/loop-init/test/cli.test.mjs
+++ b/tools/loop-init/test/cli.test.mjs
@@ -131,6 +131,8 @@ test('loop-init scaffolds circuit breaker (loop-guard + ledger) for fix patterns
     const ledger = JSON.parse(await readFile(path.join(dir, 'loop-ledger.json'), 'utf8'));
     assert.equal(typeof ledger.goal, 'string');
     assert.ok(ledger.goal.length > 0);
+    assert.equal(ledger.pattern, 'ci-sweeper');
+    assert.match(ledger.level, /^L[123]$/);
     assert.deepEqual(ledger.attempts, []);
   } finally {
     await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Follow-up to the circuit breaker landed in #140. The breaker's `--token-budget`
was left to a hand-typed number, so in practice fix loops ran with no token cap
at all. `loop-cost` already computes a realistic per-run estimate per
pattern/level — this wires the two together so the breaker trips on real cost
blowup instead of a guess.

## What

- `loop-init` seeds `loop-ledger.json` with the loop's `pattern` and `level`
  (extra fields the breaker ignores) so `loop-guard` knows what to price.
- `loop-guard` skill derives `--token-budget` from `loop-cost --json`
  (`scenarios.realistic.tokensPerRun`).
- Cross-linked from `loop-cost`'s README.

## Why this shape

Pure shell wiring — no code coupling, no new dependency. `loop-context` stays
dependency-free, and the two tools remain independently usable, matching the
repo's "independent packages, wire at the edges" convention.

## Tested

- 12/12 `loop-init` tests (new assertion: seeded ledger carries a valid
  pattern + L1/L2/L3 level); typecheck clean.
- End-to-end: scaffold `ci-sweeper` → budget resolves to 19,250 → clean ledger
  returns CONTINUE (exit 0); a ledger over budget returns
  `ESCALATE [token-budget]` (exit 2).