### PR TITLE
Docs/add mcp runtime quickstart

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -62,6 +62,22 @@ Scores 0–100 with concrete next steps. Re-run after each improvement. Paste a 
 npx @cobusgreyling/loop-audit . --badge
 ```
 
+## Optional: MCP runtime lookup
+
+If you want to use the MCP runtime locally, copy the example configuration:
+
+```bash
+cp examples/mcp/loop-engineering.mcp.json <your-mcp-config>.json
+```
+
+Then run the MCP server from your cloned repository:
+
+```bash
+node tools/mcp-server/dist/index.js
+```
+
+> **Note:** npm publishing is still pending. Run the MCP server from your local clone of the repository—do not use or document an `npx` command yet.
+
 ## 5. Run your first loop — report only (2 minutes)
 
 ### Grok

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ Same patterns, different tools. Skills and state schemas are shared; only schedu
 | Opencode | [opencode/](./opencode/) |
 | GitHub Actions | [github-actions/](./github-actions/) |
 | MCP connectors | [mcp/](./mcp/) — config example; reference server in [tools/mcp-server/](../tools/mcp-server/) |
+| Hermes | [hermes/](./hermes/) |
 
 Start with [primitives-matrix.md](../docs/primitives-matrix.md) to map capabilities.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ Same patterns, different tools. Skills and state schemas are shared; only schedu
 | GitHub Actions | [github-actions/](./github-actions/) |
 | MCP connectors | [mcp/](./mcp/) — config example; reference server in [tools/mcp-server/](../tools/mcp-server/) |
 | Hermes | [hermes/](./hermes/) |
+| Aider | [Aider CLI](../docs/primitives-matrix.md#aider-cli) — CLI-first loops via cron + `--read` skills |
 
 Start with [primitives-matrix.md](../docs/primitives-matrix.md) to map capabilities.
 

--- a/examples/cursor/README.md
+++ b/examples/cursor/README.md
@@ -6,6 +6,7 @@ Copy-pasteable loop patterns for Cursor, using **Automations** (cloud cron) or m
 |---|---|---|---|
 | Daily Triage | 1d–2h (Automation or manual) | Low | [daily-triage.md](daily-triage.md) |
 | Constraints | Every loop run (before triage) | Low | [constraints.md](constraints.md) |
+| PR Babysitter | On cadence (Automation or manual) | Medium | [pr-babysitter.md](pr-babysitter.md) |
 
 No `loop-init --tool cursor` yet — copy `SKILL.md` + `STATE.md` from any starter (e.g. `starters/minimal-loop`), then follow the example to wire scheduling.
 

--- a/examples/cursor/pr-babysitter.md
+++ b/examples/cursor/pr-babysitter.md
@@ -1,0 +1,64 @@
+# PR Babysitter — Cursor (Automations / Agent)
+
+This is a practical, copy-pasteable example of a PR babysitter loop using Cursor.
+
+Cursor has no native `/loop` scheduler. Map the loop to a **Cloud Automation** (cron)
+or trigger manually in Agent chat on cadence.
+
+## Automation prompt (week one — report only)
+
+In Cursor → Automations, create a job with a prompt like:
+
+```text
+Run the pr-review-triage skill on all open PRs.
+Update pr-babysitter-state.md with current CI status and review state.
+Do not merge or push fixes in week one — report only.
+Flag anything ambiguous or high-risk for human review in pr-babysitter-state.md.
+Use worktree + minimal-fix + loop-verifier only for allowlisted low-risk PRs.
+Escalate after 3 attempts. No auto-merge in week one.
+```
+
+Or invoke manually in Agent chat with the same prompt on your chosen cadence.
+
+## Progression
+
+- **Week one — report only.** Append to `pr-babysitter-state.md`. Read it yourself
+  before acting on any suggestion. Human gates all merges.
+- **Add minimal fixes.** Extend the automation to propose fixes in an isolated
+  worktree for allowlisted low-risk PRs only.
+- **Add connectors.** Wire PR comments and status updates via GitHub MCP
+  (read-only discovery first).
+- **Add verifier split.** A separate verifier agent approves before any comment
+  or fix is posted. Max 3 attempts per PR.
+
+## Requirements
+
+- `pr-babysitter-state.md` in the repo root (from `starters/pr-babysitter/`)
+- The `pr-review-triage` skill in `.cursor/skills/pr-review-triage/SKILL.md`
+- Optional always-on rules in `.cursor/rules/`
+- Cloud Automation for unattended cadence — manual Agent chat works for week one
+
+## Example pr-babysitter-state.md
+
+```markdown
+# PR Babysitter State
+Last run: 2026-07-05 09:00 UTC
+
+## Open PRs
+
+### #1234 — fix: correct login redirect
+- CI: green
+- Reviews: 1 approval, 1 blocking comment
+- Loop action: report only (week one). Needs human triage.
+- Attempts: 1 / 3
+```
+
+## Notes
+
+- Combine with `.cursor/rules/` for always-on constraints across all Agent sessions
+- GitHub Actions can complement the Automation when your machine is off
+- See [patterns/pr-babysitter.md](../../patterns/pr-babysitter.md) and
+  [starters/pr-babysitter](../../starters/pr-babysitter/) for the full pattern spec
+
+See the [primitives matrix](../../docs/primitives-matrix.md) for how Cursor maps
+to the same six-part loop shape.

--- a/examples/opencode/README.md
+++ b/examples/opencode/README.md
@@ -8,6 +8,7 @@ Open-source coding agent that runs from the CLI, can run headlessly via `opencod
 | [constraints.md](./constraints.md) | Constraints (binding rules loaded before every loop run) |
 | [ci-sweeper.md](./ci-sweeper.md) | CI Sweeper (cron/systemd + `opencode run` for short cadences) |
 | [pr-babysitter.md](./pr-babysitter.md) | PR Babysitter (long-running PR shepherd with worktree isolation) |
+| [Constraints Example](constraints-example.md) – Minimal loop-triage skill with recommended guardrails. |
 
 > **Starter kit:** [../../starters/minimal-loop-opencode/](../../starters/minimal-loop-opencode/) — clone-and-run scaffold for L1 daily triage.
 >

--- a/examples/opencode/constraints-example.md
+++ b/examples/opencode/constraints-example.md
@@ -1,0 +1,42 @@
+# Opencode Constraints Example
+
+This example shows how to define simple guardrails for a CLI-first workflow using Opencode.
+
+It pairs with:
+
+```bash
+loop-init --tool opencode
+```
+
+After initialization, you can customize the generated skill with project-specific constraints.
+
+## Example
+
+```text
+skills/
+└── loop-triage/
+    └── SKILL.md
+```
+
+```markdown
+# Loop Triage
+
+## Constraints
+
+- Read-only during the first week of onboarding.
+- Never force-push to any branch.
+- Only modify files directly related to the assigned issue.
+- Request confirmation before deleting or renaming files.
+- Do not expose secrets, tokens, or internal URLs.
+```
+
+## Why use constraints?
+
+Constraints help make automated workflows predictable and reduce the chance of accidental or unsafe actions.
+
+They are especially useful for new contributors or shared repositories.
+
+## Related documentation
+
+- See `docs/safety.md` for general safety guidance.
+- Compare this with the Cursor constraints example for an editor-focused workflow.

--- a/stories/multi-loop-coordination.md
+++ b/stories/multi-loop-coordination.md
@@ -1,0 +1,78 @@
+# Multi-Loop Coordination: Daily Triage + PR Babysitter
+
+## Overview
+
+I experimented with running two automation loops at the same time:
+
+- **Daily Triage** – reviews new issues and labels or prioritizes them.
+- **PR Babysitter** – monitors pull requests and reminds contributors about reviews or requested changes.
+
+Running both loops together helped distribute responsibilities, but it also introduced coordination challenges.
+
+---
+
+## Patterns and tools used
+
+### Loops
+
+- Daily Triage
+- PR Babysitter
+
+### Coordination patterns
+
+- Separation of responsibilities
+- Independent state tracking
+- Scheduled execution
+- Clear ownership of resources
+
+---
+
+## Separating state, schedules, and budgets
+
+To avoid conflicts, each loop maintained its own resources.
+
+### State files
+
+- Daily Triage → `triage-state.json`
+- PR Babysitter → `pr-state.json`
+
+Each loop only updated its own state file.
+
+### Schedules
+
+Daily Triage ran every morning.
+
+PR Babysitter ran later in the day after new pull requests were likely to appear.
+
+Staggering schedules reduced overlap.
+
+### Budgets
+
+Each loop had its own execution budget and context window.
+
+This prevented one loop from consuming resources intended for the other.
+
+---
+
+## Failure mode
+
+One issue occurred when both loops reacted to the same pull request.
+
+Daily Triage labeled the PR as needing attention while PR Babysitter generated a reminder at nearly the same time.
+
+This resulted in duplicate notifications.
+
+Another risk was context bleed, where one loop accidentally reused information that belonged to another workflow.
+
+---
+
+## Lesson learned
+
+Running multiple loops works best when every loop has:
+
+- a clearly defined responsibility,
+- separate state,
+- independent schedules,
+- and dedicated resource limits.
+
+Treat each loop as an independent worker that communicates only through well-defined shared information instead of sharing internal state.


### PR DESCRIPTION
Fixes #170 

## Summary

Add an optional MCP runtime lookup section to the Quickstart, showing how to configure and run the local MCP server from a cloned repository.

## Changes

* [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
* [x] Doc / example improvement
* [ ] Tool change (loop-audit)
* [ ] Story (includes real failure or surprise + lesson)

## Checklist (from CONTRIBUTING)

* [ ] All required sections present for patterns
* [x] Links work from README, patterns/README, starters/README, docs/index
* [x] No secrets, tokens, internal company URLs
* [ ] `STATE.md*` examples use `.example` suffix
* [ ] Safety-related content references `docs/safety.md`
* [ ] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood

* [ ] `loop-audit` passes on affected starters or this repo
* [x] Manual review of updated documentation

## Screenshots / Examples (if UI or command output)

N/A (documentation-only change)

---

*This template enforces the high bar this reference is known for.*
