### PR TITLE
Add Hermes examples index

### DIFF
--- a/examples/hermes/README.md
+++ b/examples/hermes/README.md
@@ -1,0 +1,13 @@
+# Hermes Agent
+
+[Hermes Agent](https://hermes-agent.nousresearch.com/docs) ships the six loop primitives (cronjob / skill / STATE / delegate_task / MCP / memory) in one binary — no extra runtime needed for a full L1 daily-triage loop.
+
+| Example | Pattern |
+|---------|---------|
+| [daily-triage.md](./daily-triage.md) | Daily Triage (L1 report → L2 assisted) |
+
+Optional **channel delivery** (Telegram, Slack, Discord, WhatsApp, SMS, Feishu) is Hermes's differentiator — the same cron job can post its summary into any connected home channel.
+
+No `loop-init --tool hermes` yet — copy skills and state manually, then schedule via `hermes cron`.
+
+See [docs/primitives-matrix.md](../../docs/primitives-matrix.md) for the Hermes column in the cross-tool matrix.


### PR DESCRIPTION
## Summary

Creates `examples/hermes/README.md` — an index page for Hermes Agent examples following the same format as `examples/openclaw/README.md`.

### Acceptance criteria
- [x] Table of available examples (Daily Triage, today)
- [x] One paragraph on `hermes cron` + skills + `STATE.md`
- [x] Link to `examples/README.md` pattern matrix and `docs/primitives-matrix.md` Hermes column
- [x] Note that `loop-init --tool hermes` is not scaffolded yet

Closes #161.