### PR TITLE
docs: reflect loop-mcp-server npm publish in QUICKSTART and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For developers using Grok, Claude Code, Codex, Cursor, and other AI coding agent
 | [loop-worktree](tools/loop-worktree/) | Manage isolated git worktrees per fix attempt — `npx @cobusgreyling/loop-worktree create --run-id <id> --pattern <p>` |
 | [Goal Engineering](https://github.com/cobusgreyling/goal-engineering) | **Companion:** loops discover, goals finish — `/goal` + [stack cookbook](https://github.com/cobusgreyling/goal-engineering/blob/main/docs/stack-cookbook.md) (`npx @cobusgreyling/goal doctor .`) |
 | [Stories](stories/) | Real wins and honest failures |
-| [Contributor quickstart](https://github.com/cobusgreyling/loop-engineering/discussions/123) | **Help wanted:** 12 scoped `good first issues` — comment *I'll take this* to get assigned |
+| [Contributor quickstart](https://github.com/cobusgreyling/loop-engineering/discussions/123) | **Help wanted:** 17 scoped `good first issues` — comment *I'll take this* to get assigned |
 | [Community update](https://github.com/cobusgreyling/loop-engineering/discussions/145) | **July 4:** 5.5k stars, traffic sources, contributor merges |
 | [Prior release notes](https://github.com/cobusgreyling/loop-engineering/discussions/89) | v1.5.0 — loop-sync, constraints, MCP server |
 | [Add your project](https://github.com/cobusgreyling/loop-engineering/discussions/92) | **Pinned:** Loop Ready badge + adopters list |


### PR DESCRIPTION
## Summary
Both `@cobusgreyling/loop-context` and `@cobusgreyling/loop-mcp-server` are live on npm at v1.0.0. This PR updates docs that still said publish was pending.

## Changes
- QUICKSTART §4: `npx @cobusgreyling/loop-mcp-server` one-liner (clone path kept for dev)
- QUICKSTART cheat sheet: MCP line added
- README: `loop-mcp-server` npm badge

Closes #170 (already closed — docs landed here).

## Verify
```bash
npx @cobusgreyling/loop-mcp-server --help
npx @cobusgreyling/loop-context --help
```