### PR TITLE
feat(loop-worktree): npm publish + macOS gc path fix

### DIFF
--- a/.github/workflows/release-loop-worktree.yml
+++ b/.github/workflows/release-loop-worktree.yml
@@ -1,0 +1,63 @@
+name: Release loop-worktree
+
+on:
+  push:
+    tags:
+      - 'loop-worktree-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. loop-worktree-v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: tools/loop-worktree/package-lock.json
+
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
+      - name: Install, build, test
+        working-directory: tools/loop-worktree
+        run: |
+          npm ci
+          npm run build
+          npm test
+
+      - name: Skip if version already published
+        id: check
+        working-directory: tools/loop-worktree
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@cobusgreyling/loop-worktree@${VERSION}" version 2>/dev/null; then
+            echo "Version ${VERSION} already on npm — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing @cobusgreyling/loop-worktree@${VERSION}"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        working-directory: tools/loop-worktree
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="https://www.npmjs.com/package/@cobusgreyling/loop-cost"><img src="https://img.shields.io/npm/v/@cobusgreyling/loop-cost?label=loop-cost" alt="loop-cost npm"></a>
   <a href="https://www.npmjs.com/package/@cobusgreyling/loop-sync"><img src="https://img.shields.io/npm/v/@cobusgreyling/loop-sync?label=loop-sync" alt="loop-sync npm"></a>
   <a href="https://www.npmjs.com/package/@cobusgreyling/loop-context"><img src="https://img.shields.io/npm/v/@cobusgreyling/loop-context?label=loop-context" alt="loop-context npm"></a>
+  <a href="https://www.npmjs.com/package/@cobusgreyling/loop-mcp-server"><img src="https://img.shields.io/npm/v/@cobusgreyling/loop-mcp-server?label=loop-mcp-server" alt="loop-mcp-server npm"></a>
   <a href="https://github.com/cobusgreyling/loop-engineering/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT"></a>
   <a href="https://cobusgreyling.github.io/loop-engineering/"><img src="https://img.shields.io/badge/GitHub_Pages-live%20%7C%20interactive-3ee8c5" alt="Pages"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <a href="https://www.npmjs.com/package/@cobusgreyling/loop-sync"><img src="https://img.shields.io/npm/v/@cobusgreyling/loop-sync?label=loop-sync" alt="loop-sync npm"></a>
   <a href="https://www.npmjs.com/package/@cobusgreyling/loop-context"><img src="https://img.shields.io/npm/v/@cobusgreyling/loop-context?label=loop-context" alt="loop-context npm"></a>
   <a href="https://www.npmjs.com/package/@cobusgreyling/loop-mcp-server"><img src="https://img.shields.io/npm/v/@cobusgreyling/loop-mcp-server?label=loop-mcp-server" alt="loop-mcp-server npm"></a>
+  <a href="https://www.npmjs.com/package/@cobusgreyling/loop-worktree"><img src="https://img.shields.io/npm/v/@cobusgreyling/loop-worktree?label=loop-worktree" alt="loop-worktree npm"></a>
   <a href="https://github.com/cobusgreyling/loop-engineering/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT"></a>
   <a href="https://cobusgreyling.github.io/loop-engineering/"><img src="https://img.shields.io/badge/GitHub_Pages-live%20%7C%20interactive-3ee8c5" alt="Pages"></a>
 </p>

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -76,7 +76,13 @@ npx @cobusgreyling/loop-audit . --badge
 
 Agents can query patterns, skills, and state on demand instead of stuffing docs into every prompt. Copy the config stub from [examples/mcp/loop-engineering.mcp.json](../examples/mcp/loop-engineering.mcp.json) into your MCP client settings.
 
-**npm publish is pending** — run the server from a cloned `loop-engineering` repo for now:
+Run the server from npm (no clone required):
+
+```bash
+LOOP_PROJECT_ROOT=. npx @cobusgreyling/loop-mcp-server
+```
+
+Or from a cloned `loop-engineering` repo for local development:
 
 ```bash
 cd path/to/loop-engineering/tools/mcp-server && npm ci && npm run build
@@ -173,6 +179,9 @@ npx @cobusgreyling/loop-audit . --suggest
 
 # Optional badge for your README
 npx @cobusgreyling/loop-audit . --badge
+
+# Optional MCP runtime lookup (patterns, skills, state on demand)
+LOOP_PROJECT_ROOT=. npx @cobusgreyling/loop-mcp-server
 ```
 
 ## Learn the why (optional, 10 minutes)

--- a/tools/loop-worktree/dist/worktree.js
+++ b/tools/loop-worktree/dist/worktree.js
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, access, realpath } from 'node:fs/promises';
 import path from 'node:path';
 const run = promisify(execFile);
 export const MANIFEST_DIR = '.loop-worktrees';
@@ -154,13 +154,15 @@ export async function cleanupWorktrees(input) {
 }
 /** Paths (repo-relative, posix) of every worktree git currently knows about. */
 async function gitWorktreePaths(root) {
+    const rootReal = await realpath(root);
     const out = await git(['worktree', 'list', '--porcelain'], root);
     const paths = [];
     for (const line of out.split('\n')) {
         if (!line.startsWith('worktree '))
             continue;
         const abs = line.slice('worktree '.length).trim();
-        const rel = path.relative(root, abs).split(path.sep).join('/');
+        const absReal = await realpath(abs);
+        const rel = path.relative(rootReal, absReal).split(path.sep).join('/');
         paths.push(rel);
     }
     return paths;

--- a/tools/loop-worktree/src/worktree.ts
+++ b/tools/loop-worktree/src/worktree.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, access, realpath } from 'node:fs/promises';
 import path from 'node:path';
 
 const run = promisify(execFile);
@@ -215,12 +215,14 @@ export async function cleanupWorktrees(input: CleanupInput): Promise<CleanupResu
 
 /** Paths (repo-relative, posix) of every worktree git currently knows about. */
 async function gitWorktreePaths(root: string): Promise<string[]> {
+  const rootReal = await realpath(root);
   const out = await git(['worktree', 'list', '--porcelain'], root);
   const paths: string[] = [];
   for (const line of out.split('\n')) {
     if (!line.startsWith('worktree ')) continue;
     const abs = line.slice('worktree '.length).trim();
-    const rel = path.relative(root, abs).split(path.sep).join('/');
+    const absReal = await realpath(abs);
+    const rel = path.relative(rootReal, absReal).split(path.sep).join('/');
     paths.push(rel);
   }
   return paths;


### PR DESCRIPTION
## Summary
Ship `@cobusgreyling/loop-worktree` to npm — the last CLI in the README without an npm badge.

## Changes
- **`release-loop-worktree.yml`** — publish on `loop-worktree-v*` tag push (same pattern as loop-mcp-server)
- **macOS gc fix** — `gitWorktreePaths` now resolves realpaths so `/var` vs `/private/var` symlinks don't false-positive `dropped` entries
- **README** — `loop-worktree` npm badge

## Publish steps (after merge)
```bash
git tag loop-worktree-v1.0.0
git push origin loop-worktree-v1.0.0
```

## Verify locally
```bash
cd tools/loop-worktree && npm test
npx @cobusgreyling/loop-worktree list  # after publish
```