### PR TITLE
docs: add Gemini CLI appendix to primitives matrix(#202)

### DIFF
--- a/docs/primitives-matrix.md
+++ b/docs/primitives-matrix.md
@@ -181,3 +181,30 @@ Report PASS/FAIL and do not edit files.
 ```
 
 After copying: map scheduling to manual Agent Panel threads, Terminal Threads, Zed Tasks, or an external scheduler until Zed has a richer first-class loop scheduler. Use `AGENTS.md` for always-on repo rules, `.agents/skills/<name>/SKILL.md` for reusable workflows, Agent Profiles / Tool Permissions for maker-checker separation, and MCP for external tools.
+
+## Appendix: Gemini CLI
+
+Gemini CLI is a terminal-based agent tool. Map the same loop primitives onto the `gemini` command, external schedulers, context files, and separate verification sessions.
+
+| Primitive | Gemini CLI mapping |
+|-----------|--------------------|
+| Scheduling | Use external schedulers such as cron, systemd timers, or GitHub Actions to invoke Gemini CLI workflows on a cadence. |
+| Skills / Context Files | Use project context files such as `GEMINI.md` and repository documentation to provide instructions, conventions, and background information. |
+| State | Keep persistent loop state in files such as `STATE.md.example`. Each run should read existing state, update only relevant sections, and preserve history. |
+| Maker/checker split | Use separate Gemini CLI sessions: one session creates changes, another reviews output, validates requirements, and checks the diff. |
+| Connectors | Use available MCP servers or external tools to provide additional context and capabilities. |
+
+### Week-one Daily Triage Example
+
+A Gemini CLI daily triage loop:
+
+1. Start Gemini CLI from the repository root.
+2. Read `STATE.md.example`.
+3. Review pending triage items.
+4. Update only triage sections.
+5. Do not edit source files during the first week.
+6. Save updated state for the next run.
+
+### Official Documentation
+
+https://github.com/google-gemini/gemini-cli

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ Same patterns, different tools. Skills and state schemas are shared; only schedu
 | Windsurf | [windsurf/](./windsurf/) |
 | Opencode | [opencode/](./opencode/) |
 | Hermes Agent | [hermes/](./hermes/) |
+| Gemini CLI | [primitives-matrix § Gemini CLI](../docs/primitives-matrix.md#appendix-gemini-cli) — terminal-based loops via `gemini` + external scheduling |
 | GitHub Actions | [github-actions/](./github-actions/) |
 | Aider CLI | [primitives-matrix § Aider](../docs/primitives-matrix.md#appendix-aider-cli) — CLI-first loops via cron + `--read` skills |
 | MCP connectors | [mcp/](./mcp/) — config example; reference server in [tools/mcp-server/](../tools/mcp-server/) |


### PR DESCRIPTION
## Summary

Added Gemini CLI support to the loop primitives documentation.

## Changes

- Added a new `## Appendix: Gemini CLI` section in `docs/primitives-matrix.md`.
- Mapped loop primitives to Gemini CLI workflows:
  - scheduling using cron/systemd/GitHub Actions
  - skills and context files (`GEMINI.md`)
  - state management using `STATE.md.example`
  - maker/checker workflow using separate sessions
  - week-one Daily Triage workflow

- Added a Gemini CLI entry in `examples/README.md`.

Since there is currently no dedicated `examples/gemini-cli/` directory, the README entry links directly to the Gemini CLI appendix in `primitives-matrix.md`, similar to the existing Aider CLI documentation approach.

## Testing

Documentation-only change.