### PR TITLE
docs: add npx quickstart for MCP server (#201)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ Same patterns, different tools. Skills and state schemas are shared; only schedu
 | Gemini CLI | [primitives-matrix § Gemini CLI](../docs/primitives-matrix.md#appendix-gemini-cli) — terminal-based loops via `gemini` + external scheduling |
 | GitHub Actions | [github-actions/](./github-actions/) |
 | Aider CLI | [primitives-matrix § Aider](../docs/primitives-matrix.md#appendix-aider-cli) — CLI-first loops via cron + `--read` skills |
-| MCP connectors | [mcp/](./mcp/) — config example; reference server in [tools/mcp-server/](../tools/mcp-server/) |
+| MCP connectors | [mcp/](./mcp/) — config example, including `loop-engineering.mcp.json`; reference server in [tools/mcp-server/](../tools/mcp-server/) |
 
 Start with [primitives-matrix.md](../docs/primitives-matrix.md) to map capabilities.
 

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -4,6 +4,24 @@ Practical, scoped examples for connecting loops to real tools via MCP (or equiva
 
 **Core principle**: Give loops the *minimum* privilege they need. Prefer read + comment over write. Use human gates + worktrees for anything that mutates state.
 
+## Run the loop-engineering MCP server
+
+If you want to try the MCP server without cloning the repo, use the published package:
+
+```bash
+LOOP_PROJECT_ROOT=. npx @cobusgreyling/loop-mcp-server
+```
+
+Copy the example MCP configuration:
+
+```bash
+cp examples/mcp/loop-engineering.mcp.json <your-mcp-config-location>
+```
+
+Then point your MCP client to the command above.
+
+The local clone/dev path still works if you want to inspect or change the server implementation directly; see the example configuration files below.
+
 ## Quick Patterns
 
 | Connector | Typical Use | Recommended Scope | Pattern Fit |
@@ -17,6 +35,7 @@ Practical, scoped examples for connecting loops to real tools via MCP (or equiva
 
 See the files in this directory:
 
+- `loop-engineering.mcp.json` — starter config for the published MCP server.
 - `github-readonly.mcp.json` (existing) — safe starting point for discovery.
 - `github-propose.json` — read + limited write for comments and draft PRs (sign comments as the loop).
 - `linear.json` — example for creating/updating issues from loop state.


### PR DESCRIPTION
## Summary

- Added npx quickstart instructions for running the Loop MCP server
- Added MCP configuration copy instructions using loop-engineering.mcp.json
- Updated the examples index to mention the MCP config example

## Related Issue

Fixes #201