### PR TITLE
docs(stories): add CI Sweeper failure story

### DIFF
--- a/stories/ci-sweeper-infinite-flaky-test.md
+++ b/stories/ci-sweeper-infinite-flaky-test.md
@@ -1,0 +1,19 @@
+# CI Sweeper — The Infinite Flaky Test Loop
+
+## Setup
+- **Pattern:** CI Sweeper
+- **Tool + Cadence:** GitHub Actions (triggered on every failed `main` build)
+
+## What Worked
+The CI Sweeper successfully detected the CI failure on `main` and immediately proposed a valid code change to increase the test timeout in our `e2e/third-party/` directory.
+
+## What Broke
+The underlying issue was a flaky third-party API, not just a simple timeout. 
+When the sweeper opened its fix PR, the CI ran against that PR and failed again due to the exact same flake. The sweeper then spawned *another* loop to fix its own fix. It ended up proposing 30+ iterative PRs over the weekend, just inflating `setTimeout` values endlessly. We had to manually disable the GitHub Actions workflow to stop it.
+
+## Metrics
+- ~30 automated PRs created over a single weekend.
+- Unnecessary token spend and CI compute wasted on ghost-chasing.
+
+## Lesson
+Never let a CI Sweeper auto-trigger on flaky tests without a hard daily run limit. We added a denylist in `LOOP.md` for `e2e/third-party/` and a strict budget cap of 3 automated fix attempts per day across the repository.


### PR DESCRIPTION
## Summary
Adds an honest failure story for the CI Sweeper pattern, demonstrating an infinite fix loop triggered by flaky E2E tests, resolving issue #199.

## Changes
- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example improvement
- [ ] Tool change (loop-audit)
- [x] Story (includes real failure or surprise + lesson)

## Checklist (from CONTRIBUTING)
- [ ] All required sections present for patterns
- [ ] Links work from README, patterns/README, starters/README, docs/index
- [x] No secrets, tokens, internal company URLs
- [ ] `STATE.md*` examples use `.example` suffix
- [ ] Safety-related content references `docs/safety.md`
- [x] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood
- [x] `loop-audit` passes on affected starters or this repo
- [ ] Manual review of generated state / skill output

## Screenshots / Examples (if UI or command output)
N/A - Text only failure story.

---

*This template enforces the high bar this reference is known for.*