### PR TITLE
fix(ci): install sigstore before loop-audit npm publish

### DIFF
--- a/.github/workflows/release-loop-audit.yml
+++ b/.github/workflows/release-loop-audit.yml
@@ -31,7 +31,9 @@ jobs:
           cache-dependency-path: tools/loop-audit/package-lock.json
 
       - name: Ensure npm supports trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        run: |
+          npm install -g npm@latest
+          npm install -g sigstore
 
       - name: Install, build, test
         working-directory: tools/loop-audit


### PR DESCRIPTION
Fixes loop-audit-v1.6.0 release failure: `npm publish --provenance` requires `sigstore` on the runner.