### PR TITLE
chore: Jul 10 housekeeping — docs, state, automation status

### DIFF
--- a/LOOP.md
+++ b/LOOP.md
@@ -72,6 +72,21 @@ npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok  # after npm p
 bash scripts/before-after-demo.sh
 ```
 
+## Automation status (2026-07-10)
+
+| Loop | Level | Automation | Notes |
+|------|-------|------------|-------|
+| Daily Triage | L1 | ✅ `daily-triage.yml` | Weekdays; updates `STATE.md` + `loop-run-log.md` |
+| Changelog Drafter | L1 | ✅ `changelog-drafter.yml` | Mondays; opens release-prep issue |
+| Star History | L1 | ✅ `update-star-history.yml` | Daily; auto-PR to `main` |
+| Validate + Audit | L1 | ✅ `validate-patterns.yml`, `audit.yml` | On PR + push; readiness score on PRs |
+| Dependabot | L1 | ✅ `.github/dependabot.yml` | Weekly npm (`loop-audit`, `loop-init`) + GitHub Actions |
+| PR Babysitter | L2 | ⏸ Manual | Maintainer `/loop` or `starters/pr-babysitter` — no Action yet |
+| Dependency Sweeper | L2 | ⏸ Dependabot only | Patch PRs via Dependabot; full sweeper starter is manual |
+| CI Sweeper | L2 | ⏸ Partial | Reacts via failing validate/audit; no dedicated retry workflow |
+
+**Next automation candidates:** PR Babysitter on a schedule (read-only triage comment), CI Sweeper workflow_dispatch tied to failed `audit.yml` runs.
+
 ## Evolution
 
 Journey recorded in `stories/`. Target: solid L2 with excellent observability.

--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ For developers using Grok, Claude Code, Codex, Cursor, and other AI coding agent
 | [loop-worktree](tools/loop-worktree/) | Manage isolated git worktrees per fix attempt — `npx @cobusgreyling/loop-worktree create --run-id <id> --pattern <p>` |
 | [Goal Engineering](https://github.com/cobusgreyling/goal-engineering) | **Companion:** loops discover, goals finish — `/goal` + [stack cookbook](https://github.com/cobusgreyling/goal-engineering/blob/main/docs/stack-cookbook.md) (`npx @cobusgreyling/goal doctor .`) |
 | [Stories](stories/) | Real wins and honest failures |
-| [Contributor quickstart](https://github.com/cobusgreyling/loop-engineering/discussions/123) | **Help wanted:** 25 scoped `good first issues` — comment *I'll take this* to get assigned |
+| [Contributor quickstart](https://github.com/cobusgreyling/loop-engineering/discussions/123) | **Help wanted:** 21 scoped `good first issues` — comment *I'll take this* to get assigned |
 | [Community update](https://github.com/cobusgreyling/loop-engineering/discussions/145) | **July 4:** 5.5k stars, traffic sources, contributor merges |
 | [Community week (Jul 8)](https://github.com/cobusgreyling/loop-engineering/discussions/219) | loop-worktree npm, MCP quickstart, tool appendices |
+| [Maintenance (Jul 10)](https://github.com/cobusgreyling/loop-engineering/discussions/241) | Doc sync, branch prune, loop-audit 1.6.0 follow-up |
 | [Prior release notes](https://github.com/cobusgreyling/loop-engineering/discussions/89) | v1.5.0 — loop-sync, constraints, MCP server |
 | [Add your project](https://github.com/cobusgreyling/loop-engineering/discussions/92) | **Pinned:** Loop Ready badge + adopters list |
 

--- a/RELEASE_NOTES_DRAFT.md
+++ b/RELEASE_NOTES_DRAFT.md
@@ -1,6 +1,6 @@
 # Release notes draft — since `loop-mcp-server-v1.0.0`
 
-**Status:** Published to [Discussions #219](https://github.com/cobusgreyling/loop-engineering/discussions/219) on 2026-07-08. Post-publish additions below (loop-audit 1.6.0). Archive copy for the next changelog-drafter run.
+**Status:** Published to [Discussions #219](https://github.com/cobusgreyling/loop-engineering/discussions/219) (2026-07-08) and [#241](https://github.com/cobusgreyling/loop-engineering/discussions/241) (2026-07-10 maintenance). Archive copy for the next changelog-drafter run.
 
 **Window:** 2026-07-06 → 2026-07-09
 
@@ -65,7 +65,7 @@ Thanks [@KhaiTrang1995](https://github.com/KhaiTrang1995).
 - **Star-history workflow** — opens an auto-merge PR instead of pushing to protected `main`
 - **loop-audit publish** — install `sigstore` before npm publish ([#236](https://github.com/cobusgreyling/loop-engineering/pull/236))
 - Dependabot bumps: `actions/github-script` 7→9, `@types/node` in loop-audit/loop-init
-- Stale branch prune + contributor PR backlog triage
+- Stale branch prune (18+ merged heads deleted 2026-07-10) + doc sync ([#238](https://github.com/cobusgreyling/loop-engineering/pull/238))
 
 ---
 

--- a/STATE.md
+++ b/STATE.md
@@ -10,9 +10,16 @@ Last run: 2026-07-09T10:41:53Z (automated daily-triage workflow)
 
 ## Watch List
 
-- Expand contributor failure stories (dependency sweeper, multi-loop).
-- Collect a production story for Post-Merge Cleanup.
-- Validate `loop-init` scaffolds on fresh projects across all patterns.
+- Contributor failure stories — [#119](https://github.com/cobusgreyling/loop-engineering/issues/119) (PR Babysitter), [#230](https://github.com/cobusgreyling/loop-engineering/issues/230) (multi-loop).
+- Post-Merge Cleanup production story — [#221](https://github.com/cobusgreyling/loop-engineering/issues/221).
+- `loop-init` validation checklist — [#231](https://github.com/cobusgreyling/loop-engineering/issues/231).
+
+## Housekeeping (2026-07-10)
+
+- Merged [#238](https://github.com/cobusgreyling/loop-engineering/pull/238) — version/doc sync.
+- Pruned 18+ stale remote branches (merged PR heads + abandoned patches).
+- README good-first-issue count corrected (21 open).
+- Release notes strategy documented in `docs/RELEASE.md`.
 
 ## Recent Noise (ignored this run)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -96,6 +96,18 @@ mkdir /tmp/loop-init-test && cd /tmp/loop-init-test
 npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok --dry-run
 ```
 
+## Changelog & release notes (no root `CHANGELOG.md`)
+
+This repo does **not** maintain a root `CHANGELOG.md`. Use:
+
+| Surface | Purpose |
+|---------|---------|
+| `RELEASE_NOTES_DRAFT.md` | Working draft for the next community update (changelog-drafter + human edit) |
+| [GitHub Discussions → Announcements](https://github.com/cobusgreyling/loop-engineering/discussions/categories/announcements) | Published release notes (e.g. [#89](https://github.com/cobusgreyling/loop-engineering/discussions/89), [#219](https://github.com/cobusgreyling/loop-engineering/discussions/219)) |
+| `tools/*/CHANGELOG.md` | Per-package history when a tool version bumps |
+
+After publish: trim `RELEASE_NOTES_DRAFT.md` to a short “since last discussion” stub for the next drafter run.
+
 ## Before npm is live (local / monorepo)
 
 ```bash


### PR DESCRIPTION
## Priority 1–3 housekeeping

- Fix README good-first-issue count (21 open)
- Document changelog/release-notes strategy in `docs/RELEASE.md` (no root CHANGELOG)
- Link STATE.md watch-list items to GitHub issues; log completed housekeeping
- Add automation status table to `LOOP.md`
- Refresh `RELEASE_NOTES_DRAFT.md`; published [Discussion #241](https://github.com/cobusgreyling/loop-engineering/discussions/241)

Branch prune and #238 merge already landed on `main`.