### PR TITLE
Add loop-init validation checklist (#231)

### DIFF
--- a/docs/loop-init-validation.md
+++ b/docs/loop-init-validation.md
@@ -1,0 +1,38 @@
+# loop-init Validation Checklist
+
+Tracks whether `npx @cobusgreyling/loop-init` produces a working, sane scaffold
+for each pattern × --tool combination. Fill in a row after actually running
+the command in a fresh git repo — don't guess.
+
+## How to validate a row
+
+\`\`\`
+mkdir <temp-folder> && cd <temp-folder>
+git init
+npx @cobusgreyling/loop-init . --pattern <pattern> --tool <tool>
+\`\`\`
+
+Record the printed Loop Ready score, list files created, and note anything
+unexpected. Command used for validation below (Windows/PowerShell):
+
+\`\`\`
+mkdir C:\Temp\loop-init-test
+cd C:\Temp\loop-init-test
+git init
+npx @cobusgreyling/loop-init . --pattern daily-triage --tool claude
+\`\`\`
+
+## Matrix
+
+| Pattern | --tool | Loop Ready score | Files created | Notes |
+|---|---|---|---|---|
+| daily-triage | claude | 100/100 (L3) | `.claude/skills/loop-triage/`, `.claude/agents/loop-verifier.md`, `STATE.md`, `LOOP.md`, `loop-budget.md`, `loop-run-log.md`, `loop-constraints.md`, `.claude/skills/loop-budget/SKILL.md`, `.claude/skills/loop-constraints/SKILL.md`, `AGENTS.md` (template) | Clean scaffold, no errors. Immediately scored 100/100 with no manual edits. |
+| daily-triage | grok | | | |
+| daily-triage | codex | | | |
+| daily-triage | opencode | | | |
+| ci-sweeper | claude | | | |
+| ci-sweeper | grok | | | |
+| ci-sweeper | codex | | | |
+| ci-sweeper | opencode | | | |
+
+Empty rows are open for other contributors — see #231.

--- a/tools/loop-init/README.md
+++ b/tools/loop-init/README.md
@@ -4,6 +4,8 @@ Scaffold loop engineering starters into your project by pattern and tool.
 
 **npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok** works immediately.
 
+See [docs/loop-init-validation.md](../../docs/loop-init-validation.md) for a validated pattern × --tool matrix.
+
 ## Install & Run
 
 ```bash


### PR DESCRIPTION
## Summary
Adds a loop-init validation checklist (docs/loop-init-validation.md) tracking pattern × --tool Loop Ready scores, per #231.

## Changes
- [ ] New pattern or starter
- [x] Doc / example improvement
- [ ] Tool change (loop-audit)
- [ ] Story

## Checklist (from CONTRIBUTING)
- [x] All required sections present for patterns
- [x] Links work from README, patterns/README, starters/README, docs/index
- [x] No secrets, tokens, internal company URLs
- [x] `STATE.md*` examples use `.example` suffix
- [ ] Safety-related content references `docs/safety.md`
- [x] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood
- [x] `loop-audit` passes on affected starters or this repo
- [x] Manual review of generated state / skill output

## Screenshots / Examples (if UI or command output)
Validated one row by running loop-init in a fresh git repo:

​```
mkdir C:\Temp\loop-init-test
cd C:\Temp\loop-init-test
git init
npx @cobusgreyling/loop-init . --pattern daily-triage --tool claude
​```

Output:
​```
✓ Loop Ready: 100/100 (L3)
​```

Files created: `.claude/skills/loop-triage/`, `.claude/agents/loop-verifier.md`, `STATE.md`, `LOOP.md`, `loop-budget.md`, `loop-run-log.md`, `loop-constraints.md`, `.claude/skills/loop-budget/SKILL.md`, `.claude/skills/loop-constraints/SKILL.md`, `AGENTS.md`

Closes #231
