### PR TITLE
docs: cross-link Open-Spek as a related, differently-scoped project

### DIFF
--- a/resources/sources.md
+++ b/resources/sources.md
@@ -44,6 +44,9 @@ These provide important context and guardrails for loop design.
 - **Marius ([@sololys](https://github.com/sololys))** — [KY Cut Surface Philosophy v0.1](./ky-cut-surface-philosophy-v0_1/) (July 2026)
   Archived public philosophy on the distinction between generation and consequence. Not a pattern or runtime — indexed via [stories/ky-cut-surface-generation-vs-consequence.md](../stories/ky-cut-surface-generation-vs-consequence.md).
 
+- **Open-Spek** — [open-spek/loop](https://github.com/open-spek/loop), [open-spek.github.io](https://open-spek.github.io) (July 2026)
+  An independently-developed, differently-scoped use of the term "loop engineering": a test-gated, fresh-context loop that turns a frozen Spek — the complete knowledge required to recreate a piece of software — into a verified implementation, one milestone at a time, rather than a scheduled maintenance cadence. First proof: [open-spek/jsonq](https://github.com/open-spek/jsonq) (21 iterations, 252 tests, 100 percent coverage, 0 human-edited lines). Not a pattern for this repo's registry — cross-linked here because the term collides across both projects and readers of either may otherwise conflate them.
+
 ## How This Repo Relates
 
 We treat the above sources as the current best articulation of the idea and aim to turn the abstract framework into practical, copyable patterns, templates, and tool-specific guidance (with special attention to the Grok Build TUI, which has strong native support for the primitives).


### PR DESCRIPTION
This adds a single entry to `resources/sources.md`, under **Community Philosophy Artifacts**, cross-linking [open-spek/loop](https://github.com/open-spek/loop).

## Why

Open-Spek independently arrived at the term "loop engineering" for something with a different scope than this repo: a test-gated, fresh-context loop that builds toward a milestone from a frozen Spek (the complete knowledge required to recreate a piece of software), rather than a scheduled maintenance cadence (triage, CI sweeps, dependency updates, etc.).

Same term, two independent projects, different problem. Readers who land on either repo searching "loop engineering" could otherwise conflate the two. This entry disambiguates, the same way the existing KY Cut Surface Philosophy entry cross-links a related-but-distinct body of work.

## What this is not

- Not a submission to `patterns/` or `patterns/registry.yaml` — Open-Spek's loop isn't a cadence-based pattern like the seven already in this repo.
- Not an adopters-list entry — Open-Spek doesn't use this repo's tools or patterns, so it wouldn't be honest to list it as one.

## Checklist (per CONTRIBUTING.md)

- [x] Link reachable from README (`README.md` already points to `resources/sources.md` under Sources)
- [x] No secrets, tokens, or internal URLs
- [x] Single-file, additive change; nothing else touched
