### PR TITLE
docs: sync loop-init version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For developers using Grok, Claude Code, Codex, Cursor, and other AI coding agent
 | [Starters](starters/) | Clone-and-run kits (Grok, Claude Code, Codex, Opencode) |
 | [Opencode examples](examples/opencode/) | CLI-first loops: cron/systemd + `opencode run`, skills, worktrees |
 | [loop-audit](tools/loop-audit/) | Loop Readiness Score CLI (v1.6 — constraints + governance scoring) — `npx @cobusgreyling/loop-audit . --suggest` · `--badge` for README |
-| [loop-init](tools/loop-init/) | Scaffold starters + budget/run-log + constraints (v1.3) — `npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok` |
+| [loop-init](tools/loop-init/) | Scaffold starters + budget/run-log + constraints (v1.4) — `npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok` |
 | [loop-cost](tools/loop-cost/) | Token spend estimator — `npx @cobusgreyling/loop-cost` |
 | [loop-sync](tools/loop-sync/) | Drift detection between `STATE.md` and `LOOP.md` — `npx @cobusgreyling/loop-sync .` |
 | [loop-context](tools/loop-context/) | Stateful memory manager + circuit breaker for long runs — `npx @cobusgreyling/loop-context --check --ledger run.json` |

--- a/tools/loop-init/package-lock.json
+++ b/tools/loop-init/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cobusgreyling/loop-init",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cobusgreyling/loop-init",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@cobusgreyling/loop-audit": "^1.5.0"


### PR DESCRIPTION
## Summary
Sync the checked-in loop-init version references after the package moved to 1.4.0.

## Changes
- Update the README quick-link description from loop-init v1.3 to v1.4.
- Refresh tools/loop-init/package-lock.json so its root package metadata matches package.json at 1.4.0.

## Verification
- npm test (in tools/loop-init)
- npm run validate:registry
- git diff --check