### PR TITLE
fix: remove markdown cruft from changelog-drafter.yml example

### DIFF
--- a/examples/github-actions/changelog-drafter.yml
+++ b/examples/github-actions/changelog-drafter.yml
@@ -37,8 +37,3 @@ jobs:
           script: |
             // Post a comment or create/update a release-prep issue with link to the draft.
             console.log('In production: comment with link to RELEASE_NOTES_DRAFT.md and the loop run id.');
-```
-
-This gives a starting point for event-driven or scheduled release note generation.
-
-Now the big one: showcase enhancement.


### PR DESCRIPTION
## What

`examples/github-actions/changelog-drafter.yml` ends with a stray closing code fence and two lines of editorial prose that leaked in from a markdown draft:

````text
```

This gives a starting point for event-driven or scheduled release note generation.

Now the big one: showcase enhancement.
````

## Why it matters

The trailing lines make the file invalid YAML, so it cannot be copied and used as a workflow as-is:

```text
$ npx js-yaml examples/github-actions/changelog-drafter.yml
YAMLException: end of the stream or a document separator is expected (40:1)
```

## Fix

Remove the 5 trailing lines. The file now parses cleanly with `js-yaml`. No functional content is lost — the removed sentence duplicates what the workflow's own comments already say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
