### PR TITLE
chore: scheduled maintenance — STATE.md + loop-context dep bump

### DIFF
--- a/.github/workflows/release-loop-context.yml
+++ b/.github/workflows/release-loop-context.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Ensure npm supports trusted publishing (OIDC)
         run: npm install -g npm@latest
 
+      - name: Install loop-cost (monorepo sibling tests shell out to its CLI)
+        working-directory: tools/loop-cost
+        run: npm ci
+
       - name: Install, build, test
         working-directory: tools/loop-context
         run: |

--- a/STATE.md
+++ b/STATE.md
@@ -1,18 +1,26 @@
 # Loop State — loop-engineering reference
 
-Last run: 2026-07-13T10:45:39Z (automated daily-triage workflow)
+Last run: 2026-07-13T18:45:00Z (scheduled maintenance)
 
 ## High Priority (loop is acting or waiting on human)
 
 - Maintain loop readiness score ≥ 58 (current: **100**, level **L3**).
-- Keep npm packages current after tool changes (tag `loop-audit-v*`, `loop-init-v*`, `loop-cost-v*` — see docs/RELEASE.md).
-
+- npm publish in flight: `loop-cost` 1.1.0, `loop-init` 1.4.0, `loop-context` 1.1.0 (tags pushed this run; verify Actions → Release workflows).
 
 ## Watch List
 
 - Expand contributor failure stories (dependency sweeper, multi-loop).
-- Collect a production story for Post-Merge Cleanup.
+- Collect a production story for Post-Merge Cleanup ([#221](https://github.com/cobusgreyling/loop-engineering/issues/221) closed — example landed in [#268](https://github.com/cobusgreyling/loop-engineering/pull/268)).
+- Remaining Cursor doc gaps: [#220](https://github.com/cobusgreyling/loop-engineering/issues/220) CI Sweeper, [#223](https://github.com/cobusgreyling/loop-engineering/issues/223) Changelog Drafter, [#224](https://github.com/cobusgreyling/loop-engineering/issues/224) Issue Triage.
 - Validate `loop-init` scaffolds on fresh projects across all patterns.
+
+## Housekeeping (2026-07-13 maintenance)
+
+- Merged contributor PRs [#267](https://github.com/cobusgreyling/loop-engineering/pull/267) (changelog-drafter YAML fix) and [#268](https://github.com/cobusgreyling/loop-engineering/pull/268) (Cursor post-merge cleanup).
+- No open PRs; CI green on `main`.
+- Pruned stale remote branches: `automated/daily-triage-2026-07-13`, `feat/loop-context-budget-from-pattern`.
+- Bumped `loop-context` dep on `loop-cost` to `^1.1.0` before publish.
+- Closed weekly loop report [#270](https://github.com/cobusgreyling/loop-engineering/issues/270).
 
 ## Recent Noise (ignored this run)
 

--- a/tools/loop-context/package-lock.json
+++ b/tools/loop-context/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@cobusgreyling/loop-cost": "^1.0.3"
+        "@cobusgreyling/loop-cost": "^1.1.0"
       },
       "bin": {
         "loop-context": "dist/cli.js"
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@cobusgreyling/loop-cost": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cobusgreyling/loop-cost/-/loop-cost-1.0.3.tgz",
-      "integrity": "sha512-SeGPv8hhW0hnbcDBS4c9RwKtuU726VTL3cwyDRtGaaJHO6GLpRD/5+iGgl5lbwfjH/3H+H3OleYShxpmaejVYw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@cobusgreyling/loop-cost/-/loop-cost-1.1.0.tgz",
+      "integrity": "sha512-lBT2YtTaqWpi50FqtbBEfTxeghepeOWPotIuhNC4xxy5vzJAdJGjMpHetrRbRUoa3ktH5q1lMCG8UEytru24Vw==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.0"

--- a/tools/loop-context/package.json
+++ b/tools/loop-context/package.json
@@ -49,7 +49,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@cobusgreyling/loop-cost": "^1.0.3"
+    "@cobusgreyling/loop-cost": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
Scheduled maintenance run (2026-07-13):

- Update STATE.md with maintenance findings
- Bump `loop-context` dependency on `loop-cost` to `^1.1.0` ahead of npm publish

Related: npm release tags `loop-cost-v1.1.0`, `loop-init-v1.4.0`, `loop-context-v1.1.0` pushed separately.