### PR TITLE
fix: remove unix-specific chmod from build scripts for windows compat…

### DIFF
--- a/tools/loop-context/package.json
+++ b/tools/loop-context/package.json
@@ -15,7 +15,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/cli.js",
+    "build": "tsc",
     "test": "npm run build && node --test test/*.test.mjs",
     "prepublishOnly": "npm test",
     "start": "node dist/cli.js"

--- a/tools/loop-cost/package.json
+++ b/tools/loop-cost/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "bundle": "node scripts/bundle-registry.mjs",
-    "build": "npm run bundle && tsc && chmod +x dist/cli.js",
+    "build": "npm run bundle && tsc",
     "test": "npm run build && node --test test/estimator.test.mjs",
     "prepublishOnly": "npm test",
     "start": "node dist/cli.js"

--- a/tools/loop-worktree/package.json
+++ b/tools/loop-worktree/package.json
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/cli.js",
+    "build": "tsc",
     "test": "npm run build && node --test test/*.test.mjs",
     "prepublishOnly": "npm test",
     "start": "node dist/cli.js"

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/index.js",
+    "build": "tsc",
     "test": "npm run build && node --test test/server.test.mjs",
     "prepublishOnly": "npm test",
     "start": "node dist/index.js"


### PR DESCRIPTION
## Summary
Removes the unix-specific `chmod +x` command from the `package.json` build scripts in `tools/` to fix build and test suite failures on Windows environments.

## Changes
- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example improvement
- [x] Tool change (loop-cost, loop-context, mcp-server, loop-worktree)
- [ ] Story (includes real failure or surprise + lesson)

## Checklist (from CONTRIBUTING)
- [ ] All required sections present for patterns
- [ ] Links work from README, patterns/README, starters/README, docs/index
- [x] No secrets, tokens, internal company URLs
- [ ] `STATE.md*` examples use `.example` suffix
- [ ] Safety-related content references `docs/safety.md`
- [x] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood
- [x] `npm run test:tools` now passes on affected tools on Windows.
- [ ] Manual review of generated state / skill output

## Screenshots / Examples (if UI or command output)
**Before:**
```text
'chmod' is not recognized as an internal or external command,
operable program or batch file.
```
closes #286 