### PR TITLE
fix(build): drop chmod +x from build scripts, npm handles it on install

### DIFF
--- a/tools/loop-context/package.json
+++ b/tools/loop-context/package.json
@@ -15,7 +15,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/cli.js",
+    "build": "tsc",
     "test": "npm run build && node --test test/*.test.mjs",
     "prepublishOnly": "npm test",
     "start": "node dist/cli.js"

--- a/tools/loop-cost/package.json
+++ b/tools/loop-cost/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "bundle": "node scripts/bundle-registry.mjs",
-    "build": "npm run bundle && tsc && chmod +x dist/cli.js",
+    "build": "npm run bundle && tsc",
     "test": "npm run build && node --test test/estimator.test.mjs",
     "prepublishOnly": "npm test",
     "start": "node dist/cli.js"

--- a/tools/loop-worktree/package.json
+++ b/tools/loop-worktree/package.json
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/cli.js",
+    "build": "tsc",
     "test": "npm run build && node --test test/*.test.mjs",
     "prepublishOnly": "npm test",
     "start": "node dist/cli.js"

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/index.js",
+    "build": "tsc",
     "test": "npm run build && node --test test/server.test.mjs",
     "prepublishOnly": "npm test",
     "start": "node dist/index.js"


### PR DESCRIPTION
## Summary

`tsc && chmod +x dist/cli.js` breaks `npm run build`/`npm test` on native
Windows shells (cmd.exe, PowerShell) that don't have `chmod` available.

## Why drop it instead of reimplementing portably

The step is unnecessary, not just non-portable: npm's bin-linking already
chmods the target file executable at install time regardless of the source
permission bit -- this is exactly why `loop-init`, `loop-audit`, `loop-sync`,
and `goal-audit` (none of which chmod in their build script) already work
fine via `npx @cobusgreyling/loop-init .`, the README's own headline command.
And every invocation of these CLIs in this repo -- including every test
suite -- spawns them via `node <path>` explicitly, never relying on the
executable bit or shebang.

## What

Drop `&& chmod +x dist/<entry>.js` from the `build` script in:
`loop-context`, `loop-cost`, `loop-worktree`, `mcp-server`. No other changes.

## Tested

Clean rebuild + full test suite for all 4 packages, run twice: once through
Git Bash (43/12/28/22 passing) and once through native PowerShell with no
Git Bash on the PATH (confirmed the old script actually fails there with
`chmod` unrecognized, and the fixed script succeeds).