### PR TITLE
chore: scheduled maintenance — Jul 16 housekeeping

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,18 +2,27 @@
 
 Thank you to everyone who shipped docs, stories, examples, and tool fixes.
 
-*Generated 2026-07-07 via `node scripts/generate-contributors.mjs` — re-run after merges.*
+*Generated 2026-07-16 via `node scripts/generate-contributors.mjs` — re-run after merges.*
 
 | Contributor | Highlights |
 |-------------|------------|
-| [@KhaiTrang1995](https://github.com/KhaiTrang1995) | #190 feat(loop-worktree): manage isolated git worktrees per fix attempt<br>#165 feat(loop-guard): size the token budget from loop-cost per pattern |
-| [@k-anushka14](https://github.com/k-anushka14) | #185 Docs/add aider to examples index<br>#183 Docs/opencode constraints example |
+| [@KhaiTrang1995](https://github.com/KhaiTrang1995) | #274 feat(loop-worktree): add advisory path locking to prevent multi-loop collisions<br>#273 feat(loop-context): track daily token spend across runs, add --on-exceed hook |
+| [@k-anushka14](https://github.com/k-anushka14) | #249 Add Codeium (Windsurf) appendix to primitives matrix (#228)<br>#248 Add loop-init validation checklist (#231) |
+| [@Mahizhan-S](https://github.com/Mahizhan-S) | #251 docs: added Cursor Dependency Sweeper example #222<br>#217 docs: add npx quickstart for MCP server (#201) |
 | [@50thycal](https://github.com/50thycal) | story: `quant-loop-out-of-time.md`<br>story: `quant-loop-the-verifier-problem.md` |
+| [@AIMindCrafter](https://github.com/AIMindCrafter) | #268 feat: add post-merge cleanup example for Cursor and update documentat…<br>#257 docs: add dependency-vs-ci-sweeper-collision failure story #230 |
+| [@roian6](https://github.com/roian6) | #208 docs: add Windsurf PR Babysitter example<br>#127 docs: expand Aider primitives appendix |
 | [@neerajdad123-byte](https://github.com/neerajdad123-byte) | 3 commits |
 | [@sololys](https://github.com/sololys) | story: `ky-cut-surface-generation-vs-consequence.md` |
 | [@ulises-jeremias](https://github.com/ulises-jeremias) | #98 docs(examples): add opencode tool coverage |
+| [@a-yeyang](https://github.com/a-yeyang) | #263 docs: add loop-sync subsection to QUICKSTART |
+| [@Angriff36](https://github.com/Angriff36) | #267 fix: remove markdown cruft from changelog-drafter.yml example |
+| [@cevheri](https://github.com/cevheri) | #252 docs: cross-link Open-Spek as a related, differently-scoped project |
+| [@CooperSheroy](https://github.com/CooperSheroy) | #259 docs: sync loop-init version references |
+| [@DavidReque](https://github.com/DavidReque) | #234 docs(stories): add CI Sweeper failure story |
 | [@jiaobotao](https://github.com/jiaobotao) | #141 Add Hermes Agent example (daily-triage) + primitives matrix column |
-| [@roian6](https://github.com/roian6) | #127 docs: expand Aider primitives appendix |
+| [@KevinGuo1007](https://github.com/KevinGuo1007) | #206 docs: add Zed appendix to primitives matrix |
+| [@lorenzobosio](https://github.com/lorenzobosio) | #247 docs(examples): add Hermes PR Babysitter example |
 | [@Zhang-986](https://github.com/Zhang-986) | #138 fix(loop-sync): honor json output flag |
 
 ## Your first PR

--- a/LOOP.md
+++ b/LOOP.md
@@ -9,7 +9,7 @@ The goal of this repo is to be the canonical, copyable, high-signal collection o
 ### Daily Triage (L1 — automated + report)
 - Cadence: 1d weekdays (`/.github/workflows/daily-triage.yml`)
 - Skill: `loop-triage` (from `skills/` and `starters/minimal-loop`)
-- State: `STATE.md` (updated by workflow; human reviews weekly issue)
+- State: STATE.md (updated by workflow; human reviews weekly issue)
 - Phase: Report-only. Human reviews and decides actions.
 - Handoff: Design decisions, large refactors, new pattern acceptance.
 

--- a/STATE.md
+++ b/STATE.md
@@ -5,7 +5,7 @@ Last run: 2026-07-15T09:44:51Z (automated daily-triage workflow)
 ## High Priority (loop is acting or waiting on human)
 
 - Maintain loop readiness score ≥ 58 (current: **100**, level **L3**).
-- Keep npm packages current after tool changes (tag `loop-audit-v*`, `loop-init-v*`, `loop-cost-v*` — see docs/RELEASE.md).
+- Keep npm packages current after tool changes (tag `loop-audit-v*`, `loop-init-v*`, `loop-cost-v*`, `loop-context-v*`, `loop-worktree-v*` — see docs/RELEASE.md). **Pending publish:** `loop-context` 1.2.0, `loop-worktree` 1.1.0 (merged #273, #274).
 
 
 ## Watch List

--- a/loop-run-log.md
+++ b/loop-run-log.md
@@ -21,7 +21,6 @@ Append one entry per run. Prune entries older than 30 days.
 
 <!-- Loop appends below this line -->
 
-{"run_id":"2026-06-15T13:42:57Z","pattern":"daily-triage","duration_s":5,"items_found":1,"actions_taken":1,"escalations":0,"tokens_estimate":52000,"readiness_score":100,"outcome":"report-only","workflow_run":"27550503677"}
 {"run_id":"2026-06-16T12:43:13Z","pattern":"daily-triage","duration_s":10,"items_found":1,"actions_taken":1,"escalations":0,"tokens_estimate":52000,"readiness_score":100,"outcome":"report-only","workflow_run":"27618341632"}
 {"run_id":"2026-06-17T12:08:32Z","pattern":"daily-triage","duration_s":12,"items_found":1,"actions_taken":1,"escalations":0,"tokens_estimate":52000,"readiness_score":100,"outcome":"report-only","workflow_run":"27687793882"}
 {"run_id":"2026-06-18T11:41:06Z","pattern":"daily-triage","duration_s":8,"items_found":2,"actions_taken":1,"escalations":1,"tokens_estimate":52000,"readiness_score":100,"outcome":"escalated","workflow_run":"27756924361"}


### PR DESCRIPTION
## Summary

Scheduled maintenance pass for the reference repo.

- **CONTRIBUTORS.md** — regenerated (18 contributors; highlights for #273, #274, and recent doc/example PRs)
- **loop-run-log.md** — pruned 1 entry older than 30 days
- **LOOP.md** — fixed `State: STATE.md` reference (backticks broke `loop-sync` detection; score 80 → 90)
- **STATE.md** — noted pending npm publish for `loop-context` 1.2.0 and `loop-worktree` 1.1.0 (merged #273, #274)

## Verification

- `npm run contributors:check` ✓
- `npm run validate:registry` ✓
- `npm run check:loop-init` ✓
- `npm run test:tools` ✓ (all 143 tests pass)
- `loop-audit .` → 100/100 L3
- `loop-sync .` → 90/100 (structural similarity warning expected)

## Local housekeeping (not in PR)

- Pruned 53 stale local git branches
- Removed untracked `assets/.DS_Store`
- Fast-forwarded `main` to latest (6 commits behind)