### PR TITLE
chore: scheduled maintenance — STATE.md, loop-context 1.3.0

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,18 +1,25 @@
 # Loop State — loop-engineering reference
 
-Last run: 2026-07-16T09:50:58Z (automated daily-triage workflow)
+Last run: 2026-07-16T12:00:00Z (scheduled maintenance)
 
 ## High Priority (loop is acting or waiting on human)
 
 - Maintain loop readiness score ≥ 58 (current: **100**, level **L3**).
-- Keep npm packages current after tool changes (tag `loop-audit-v*`, `loop-init-v*`, `loop-cost-v*` — see docs/RELEASE.md).
-
+- npm publish in flight: `loop-worktree` 1.2.0, `loop-context` 1.3.0 (tags pushed this run). **`loop-gate` 1.0.0** still needs a `release-loop-gate.yml` workflow before first publish.
 
 ## Watch List
 
 - Expand contributor failure stories (dependency sweeper, multi-loop).
 - Collect a production story for Post-Merge Cleanup.
+- Remaining Cursor doc gaps: [#220](https://github.com/cobusgreyling/loop-engineering/issues/220), [#223](https://github.com/cobusgreyling/loop-engineering/issues/223), [#224](https://github.com/cobusgreyling/loop-engineering/issues/224).
 - Validate `loop-init` scaffolds on fresh projects across all patterns.
+
+## Housekeeping (2026-07-16 maintenance)
+
+- Merged [#288](https://github.com/cobusgreyling/loop-engineering/pull/288) (architecture diagrams) and [#296](https://github.com/cobusgreyling/loop-engineering/pull/296) (loop-context similarity stagnation).
+- No open PRs; CI green on `main`.
+- Pruned stale remote branches (automated daily-triage, star-history, merged feature/fix branches).
+- Bumped `loop-context` to 1.3.0 for npm publish after #296.
 
 ## Recent Noise (ignored this run)
 

--- a/tools/loop-context/package.json
+++ b/tools/loop-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobusgreyling/loop-context",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Stateful memory manager for agent loops — summarize, prune, and inject context, with a circuit breaker that escalates stagnant or no-progress runs instead of burning tokens.",
   "type": "module",
   "main": "dist/context-manager.js",


### PR DESCRIPTION
Scheduled maintenance (2026-07-16): STATE.md update, bump loop-context to 1.3.0 after #296 for npm publish.