### PR TITLE
feat: wire loop-gate into starter loop scripts

### DIFF
--- a/starters/changelog-drafter-opencode/opencode.json.example
+++ b/starters/changelog-drafter-opencode/opencode.json.example
@@ -15,7 +15,7 @@
       "name": "implementer",
       "description": "L2 implementer for creating changelog PRs.",
       "mode": "subagent",
-      "prompt": "Commit the approved release notes to a new branch and open a draft PR. Flag breaking changes and security items explicitly in the PR body. Do not merge.",
+      "prompt": "Run npx @cobusgreyling/loop-gate check --action commit --paths <changed_files> before committing. Commit the approved release notes to a new branch and open a draft PR. Flag breaking changes and security items explicitly in the PR body. Do not merge.",
       "permission": {
         "bash": "ask",
         "edit": "ask"

--- a/starters/ci-sweeper-opencode/README.md
+++ b/starters/ci-sweeper-opencode/README.md
@@ -22,7 +22,7 @@ Start (L2 cautious — CI sweeper is action-oriented from week one):
 
 ```bash
 opencode run \
-  "Run skills/ci-triage/SKILL.md. Classify each failing check. For clear single-file regressions, create a worktree and apply a minimal fix with verifier. Update ci-sweeper-state.md. Infra and security failures: escalate." \
+  "Run skills/ci-triage/SKILL.md. Classify each failing check. For clear single-file regressions, create a worktree and apply a minimal fix with verifier. Run loop-gate check before commit. Update ci-sweeper-state.md. Infra and security failures: escalate." \
   --title "CI sweeper"
 ```
 

--- a/starters/ci-sweeper-opencode/opencode.json.example
+++ b/starters/ci-sweeper-opencode/opencode.json.example
@@ -15,7 +15,7 @@
       "name": "implementer",
       "description": "L2 implementer for CI-fix patches inside an isolated worktree.",
       "mode": "subagent",
-      "prompt": "Implement the minimal fix for the identified CI failure inside the supplied worktree. Run tests. Output the diff path. Max 3 attempts per item.",
+      "prompt": "Implement the minimal fix for the identified CI failure inside the supplied worktree. Run tests. Run npx @cobusgreyling/loop-gate check --action commit --paths <changed_files> before committing. Output the diff path. Max 3 attempts per item.",
       "permission": {
         "bash": "ask",
         "edit": "ask"

--- a/starters/ci-sweeper/README.md
+++ b/starters/ci-sweeper/README.md
@@ -19,7 +19,7 @@ Scaffold for the [CI Sweeper](../../patterns/ci-sweeper.md) loop.
 
 3. Start (Grok):
    ```bash
-   /loop 15m Check CI on main. Update ci-sweeper-state.md. Classify failures. For new actionable failures (not flakes): worktree + minimal-fix + loop-verifier. Escalate after 3 attempts.
+   /loop 15m Check CI on main. Update ci-sweeper-state.md. Classify failures. For new actionable failures (not flakes): worktree + minimal-fix + loop-verifier. Run loop-gate check before commit. Escalate after 3 attempts.
    ```
 
 ## Flake Policy

--- a/starters/dependency-sweeper-opencode/README.md
+++ b/starters/dependency-sweeper-opencode/README.md
@@ -22,7 +22,7 @@ Start (L2 assisted, patch-only):
 
 ```bash
 opencode run \
-  "Run skills/dependency-triage/SKILL.md. Scan package manifests for outdated and vulnerable deps. Patch-only auto-fix in worktree with verifier. Escalate majors, high-sev CVEs, and denylist packages. Update state." \
+  "Run skills/dependency-triage/SKILL.md. Scan package manifests for outdated and vulnerable deps. Patch-only auto-fix in worktree with verifier. Run loop-gate check before commit. Escalate majors, high-sev CVEs, and denylist packages. Update state." \
   --title "Dependency sweeper"
 ```
 

--- a/starters/dependency-sweeper-opencode/opencode.json.example
+++ b/starters/dependency-sweeper-opencode/opencode.json.example
@@ -15,7 +15,7 @@
       "name": "implementer",
       "description": "L2 implementer for patch-only dependency upgrades in a worktree.",
       "mode": "subagent",
-      "prompt": "Apply the identified patch-only upgrade inside the supplied worktree. Run npm ci && npm test. Never touch denylisted packages. Output the diff.",
+      "prompt": "Apply the identified patch-only upgrade inside the supplied worktree. Run npm ci && npm test. Run npx @cobusgreyling/loop-gate check --action commit --paths <changed_files> before committing. Never touch denylisted packages. Output the diff.",
       "permission": {
         "bash": "ask",
         "edit": "ask"

--- a/starters/dependency-sweeper/README.md
+++ b/starters/dependency-sweeper/README.md
@@ -24,7 +24,7 @@ Claude Code / Codex: use `--tool claude` or `--tool codex` with `loop-init`.
 Start (Grok):
 
 ```
-/loop 6h Run dependency-triage on package manifests and lockfiles. Patch-only auto-fix in worktree + verifier (npm ci && npm test). Escalate majors, high-sev CVEs, and denylist packages. Update dependency-sweeper-state.md.
+/loop 6h Run dependency-triage on package manifests and lockfiles. Patch-only auto-fix in worktree + verifier (npm ci && npm test). Run loop-gate check before commit. Escalate majors, high-sev CVEs, and denylist packages. Update dependency-sweeper-state.md.
 ```
 
 ## What's Included

--- a/starters/post-merge-cleanup-opencode/opencode.json.example
+++ b/starters/post-merge-cleanup-opencode/opencode.json.example
@@ -15,7 +15,7 @@
       "name": "implementer",
       "description": "L2 implementer for small cleanup fixes inside an isolated worktree.",
       "mode": "subagent",
-      "prompt": "Implement only the requested single-file cleanup inside the supplied worktree. Run tests. Never touch denylist paths. Output the diff.",
+      "prompt": "Implement only the requested single-file cleanup inside the supplied worktree. Run tests. Run npx @cobusgreyling/loop-gate check --action commit --paths <changed_files> before committing. Never touch denylist paths. Output the diff.",
       "permission": {
         "bash": "ask",
         "edit": "ask"

--- a/starters/post-merge-cleanup/README.md
+++ b/starters/post-merge-cleanup/README.md
@@ -17,7 +17,7 @@ cp starters/post-merge-cleanup/LOOP.md .
 Start (Grok):
 
 ```
-/loop 1d Run post-merge-scan on merges to main (last 7d). Update post-merge-state.md. Small doc/link fixes only in worktree. Escalate refactors.
+/loop 1d Run post-merge-scan on merges to main (last 7d). Update post-merge-state.md. Small doc/link fixes only in worktree. Run loop-gate check before commit. Escalate refactors.
 ```
 
 ## Files

--- a/starters/pr-babysitter-opencode/opencode.json.example
+++ b/starters/pr-babysitter-opencode/opencode.json.example
@@ -15,7 +15,7 @@
       "name": "implementer",
       "description": "L2 implementer for minimal PR fixes inside an isolated worktree.",
       "mode": "subagent",
-      "prompt": "Implement only the requested minimal fix inside the supplied worktree. Respect AGENTS.md and LOOP.md. Run documented tests. Never force-push. Draft PR by default.",
+      "prompt": "Implement only the requested minimal fix inside the supplied worktree. Respect AGENTS.md and LOOP.md. Run documented tests. Run npx @cobusgreyling/loop-gate check --action commit --paths <changed_files> before committing. Never force-push. Draft PR by default.",
       "permission": {
         "bash": "ask",
         "edit": "ask"

--- a/starters/pr-babysitter/README.md
+++ b/starters/pr-babysitter/README.md
@@ -17,7 +17,7 @@ Scaffold for the [PR Babysitter](../../patterns/pr-babysitter.md) loop (L2 — a
 
 3. Start (Grok):
    ```bash
-   /loop 5m Check open PRs. Update pr-babysitter-state.md. For CI failures or actionable review comments on allowlisted PRs: worktree + minimal-fix + loop-verifier. Never merge — propose only. Escalate after 3 attempts per PR.
+   /loop 5m Check open PRs. Update pr-babysitter-state.md. For CI failures or actionable review comments on allowlisted PRs: worktree + minimal-fix + loop-verifier. Run loop-gate check before commit. Never merge — propose only. Escalate after 3 attempts per PR.
    ```
 
 4. Sign PR comments: `🤖 Loop Engineering — PR Babysitter`


### PR DESCRIPTION
## Summary
Wire `loop-gate` into the pattern starters to mechanically enforce the static safety policy before agents commit or merge code.

## Changes
- [x] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example improvement
- [x] Tool change (loop-audit)
- [ ] Story (includes real failure or surprise + lesson)

## Checklist (from CONTRIBUTING)
- [x] All required sections present for patterns
- [x] Links work from README, patterns/README, starters/README, docs/index
- [x] No secrets, tokens, internal company URLs
- [x] `STATE.md*` examples use `.example` suffix
- [x] Safety-related content references `docs/safety.md`
- [x] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood
- [x] `loop-audit` passes on affected starters or this repo (Score 100/100, L3)
- [x] Manual review of generated state / skill output

## Screenshots / Examples (if UI or command output)
N/A (Backend loop prompt and configuration updates).