### PR TITLE
Feat mcp loop gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "test:loop-cost": "cd tools/loop-cost && npm test",
     "test:loop-sync": "cd tools/loop-sync && npm test",
     "test:loop-context": "cd tools/loop-context && npm test",
+    "test:loop-gate": "cd tools/loop-gate && npm test",
     "test:mcp-server": "cd tools/mcp-server && npm test",
     "test:loop-worktree": "cd tools/loop-worktree && npm test",
-    "test:tools": "npm run test:loop-audit && npm run test:loop-init && npm run test:loop-cost && npm run test:loop-sync && npm run test:loop-context && npm run test:mcp-server && npm run test:loop-worktree",
-    "build:tools": "cd tools/loop-audit && npm run build && cd ../loop-init && npm run build && cd ../loop-cost && npm run build && cd ../loop-sync && npm run build && cd ../loop-context && npm run build && cd ../mcp-server && npm run build && cd ../loop-worktree && npm run build",
+    "test:tools": "npm run test:loop-audit && npm run test:loop-init && npm run test:loop-cost && npm run test:loop-sync && npm run test:loop-context && npm run test:loop-gate && npm run test:mcp-server && npm run test:loop-worktree",
+    "build:tools": "cd tools/loop-audit && npm run build && cd ../loop-init && npm run build && cd ../loop-cost && npm run build && cd ../loop-sync && npm run build && cd ../loop-context && npm run build && cd ../loop-gate && npm run build && cd ../mcp-server && npm run build && cd ../loop-worktree && npm run build",
     "contributors:generate": "node scripts/generate-contributors.mjs",
     "contributors:check": "node scripts/generate-contributors.mjs --check"
   },

--- a/scripts/ci-validate-gates.sh
+++ b/scripts/ci-validate-gates.sh
@@ -44,6 +44,11 @@ cd ../loop-context
 npm ci
 npm test
 
+echo "Building and testing loop-gate…"
+cd ../loop-gate
+npm ci
+npm test
+
 echo "Building and testing mcp-server…"
 cd ../mcp-server
 npm ci

--- a/tools/mcp-server/dist/index.js
+++ b/tools/mcp-server/dist/index.js
@@ -2,7 +2,9 @@
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { resolveProjectRoot, loadRegistry, loadPatternDoc, listSkills, loadSkill, loadState, listStateFiles, loadLoopConfig, loadBudget, loadRunLog, loadSafetyDoc, listPatternDocs, } from './resolver.js';
+import path from 'node:path';
+import { loadGateConfig, checkGate } from '@cobusgreyling/loop-gate';
+import { resolveProjectRoot, loadRegistry, loadPatternDoc, listSkills, loadSkill, loadState, listStateFiles, loadLoopConfig, loadBudget, loadRunLog, loadSafetyDoc, listPatternDocs, loadGatePolicy, } from './resolver.js';
 const server = new McpServer({
     name: 'loop-engineering',
     version: '1.0.0',
@@ -60,6 +62,17 @@ server.resource('safety', 'loop://safety', { description: 'Safety documentation 
                 uri: 'loop://safety',
                 mimeType: 'text/markdown',
                 text: content ?? 'No safety documentation found',
+            }],
+    };
+});
+server.resource('gate', 'loop://gate', { description: 'gate.yaml — Machine-readable safety policy (path denylist, auto-merge allowlist)' }, async () => {
+    const root = await resolveProjectRoot();
+    const content = await loadGatePolicy(root);
+    return {
+        contents: [{
+                uri: 'loop://gate',
+                mimeType: 'text/yaml',
+                text: content ?? 'No gate.yaml policy found',
             }],
     };
 });
@@ -305,6 +318,33 @@ server.tool('loop_estimate_cost', 'Estimate daily token cost for a pattern at a 
     ];
     if (realisticPerDay > cost.suggested_daily_cap) {
         lines.push('', `> Warning: realistic estimate exceeds daily cap of ${fmt(cost.suggested_daily_cap)}`);
+    }
+    return { content: [{ type: 'text', text: lines.join('\n') }] };
+});
+server.tool('loop_gate_check', 'Evaluate a proposed change against the static safety policy (gate.yaml) to see if it triggers the denylist or exceeds thresholds', {
+    action: z.enum(['commit', 'merge', 'auto-merge']).describe('What the loop is about to do'),
+    paths: z.array(z.string()).describe('List of changed file paths'),
+}, async ({ action, paths }) => {
+    const root = await resolveProjectRoot();
+    const gateFile = path.join(root, 'gate.yaml');
+    let config;
+    try {
+        config = await loadGateConfig(gateFile);
+    }
+    catch (err) {
+        return { content: [{ type: 'text', text: `Error loading gate policy: ${err.message}` }] };
+    }
+    const decision = checkGate({ config, action: action, paths });
+    const lines = [
+        `## Gate Decision: ${decision.allowed ? '✅ ALLOWED' : '❌ BLOCKED'}`,
+        `- **Trigger:** ${decision.trigger}`,
+        `- **Reason:** ${decision.reason}`
+    ];
+    if (decision.matchedPaths.length > 0) {
+        lines.push('', '**Matched Paths:**');
+        for (const p of decision.matchedPaths) {
+            lines.push(`- ${p}`);
+        }
     }
     return { content: [{ type: 'text', text: lines.join('\n') }] };
 });

--- a/tools/mcp-server/dist/resolver.d.ts
+++ b/tools/mcp-server/dist/resolver.d.ts
@@ -44,4 +44,5 @@ export declare function loadLoopConfig(root: string): Promise<string | null>;
 export declare function loadBudget(root: string): Promise<string | null>;
 export declare function loadRunLog(root: string): Promise<string | null>;
 export declare function loadSafetyDoc(root: string): Promise<string | null>;
+export declare function loadGatePolicy(root: string): Promise<string | null>;
 export declare function listPatternDocs(root: string): Promise<string[]>;

--- a/tools/mcp-server/dist/resolver.js
+++ b/tools/mcp-server/dist/resolver.js
@@ -134,6 +134,9 @@ export async function loadSafetyDoc(root) {
     }
     return null;
 }
+export async function loadGatePolicy(root) {
+    return readFileIfExists(path.join(root, 'gate.yaml'));
+}
 export async function listPatternDocs(root) {
     const patternsDir = path.join(root, 'patterns');
     if (!(await fileExists(patternsDir)))

--- a/tools/mcp-server/package-lock.json
+++ b/tools/mcp-server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@cobusgreyling/loop-gate": "file:../loop-gate",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "yaml": "^2.8.0",
         "zod": "^3.25 || ^4.0"
@@ -23,6 +24,29 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "../loop-gate": {
+      "name": "@cobusgreyling/loop-gate",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.0",
+        "yaml": "^2.8.0"
+      },
+      "bin": {
+        "loop-gate": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cobusgreyling/loop-gate": {
+      "resolved": "../loop-gate",
+      "link": true
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",

--- a/tools/mcp-server/package-lock.json
+++ b/tools/mcp-server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@cobusgreyling/loop-gate": "file:../loop-gate",
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "minimatch": "^10.2.5",
         "yaml": "^2.8.0",
         "zod": "^3.25 || ^4.0"
       },
@@ -156,6 +157,15 @@
         }
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -191,6 +201,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -782,6 +804,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@cobusgreyling/loop-gate": "file:../loop-gate",
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "minimatch": "^10.2.5",
     "yaml": "^2.8.0",
     "zod": "^3.25 || ^4.0"
   },

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -43,6 +43,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@cobusgreyling/loop-gate": "file:../loop-gate",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "yaml": "^2.8.0",
     "zod": "^3.25 || ^4.0"

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -3,6 +3,8 @@
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
+import path from 'node:path';
+import { loadGateConfig, checkGate } from '@cobusgreyling/loop-gate';
 import {
   resolveProjectRoot,
   loadRegistry,
@@ -16,6 +18,7 @@ import {
   loadRunLog,
   loadSafetyDoc,
   listPatternDocs,
+  loadGatePolicy,
 } from './resolver.js';
 
 const server = new McpServer({
@@ -105,6 +108,23 @@ server.resource(
         uri: 'loop://safety',
         mimeType: 'text/markdown',
         text: content ?? 'No safety documentation found',
+      }],
+    };
+  },
+);
+
+server.resource(
+  'gate',
+  'loop://gate',
+  { description: 'gate.yaml — Machine-readable safety policy (path denylist, auto-merge allowlist)' },
+  async () => {
+    const root = await resolveProjectRoot();
+    const content = await loadGatePolicy(root);
+    return {
+      contents: [{
+        uri: 'loop://gate',
+        mimeType: 'text/yaml',
+        text: content ?? 'No gate.yaml policy found',
       }],
     };
   },
@@ -422,6 +442,43 @@ server.tool(
       lines.push('', `> Warning: realistic estimate exceeds daily cap of ${fmt(cost.suggested_daily_cap)}`);
     }
 
+    return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+  },
+);
+
+server.tool(
+  'loop_gate_check',
+  'Evaluate a proposed change against the static safety policy (gate.yaml) to see if it triggers the denylist or exceeds thresholds',
+  {
+    action: z.enum(['commit', 'merge', 'auto-merge']).describe('What the loop is about to do'),
+    paths: z.array(z.string()).describe('List of changed file paths'),
+  },
+  async ({ action, paths }) => {
+    const root = await resolveProjectRoot();
+    const gateFile = path.join(root, 'gate.yaml');
+    
+    let config;
+    try {
+      config = await loadGateConfig(gateFile);
+    } catch (err: any) {
+      return { content: [{ type: 'text' as const, text: `Error loading gate policy: ${err.message}` }] };
+    }
+
+    const decision = checkGate({ config, action: action as any, paths });
+    
+    const lines = [
+      `## Gate Decision: ${decision.allowed ? '✅ ALLOWED' : '❌ BLOCKED'}`,
+      `- **Trigger:** ${decision.trigger}`,
+      `- **Reason:** ${decision.reason}`
+    ];
+    
+    if (decision.matchedPaths.length > 0) {
+      lines.push('', '**Matched Paths:**');
+      for (const p of decision.matchedPaths) {
+        lines.push(`- ${p}`);
+      }
+    }
+    
     return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
   },
 );

--- a/tools/mcp-server/src/resolver.ts
+++ b/tools/mcp-server/src/resolver.ts
@@ -173,6 +173,10 @@ export async function loadSafetyDoc(root: string): Promise<string | null> {
   return null;
 }
 
+export async function loadGatePolicy(root: string): Promise<string | null> {
+  return readFileIfExists(path.join(root, 'gate.yaml'));
+}
+
 export async function listPatternDocs(root: string): Promise<string[]> {
   const patternsDir = path.join(root, 'patterns');
   if (!(await fileExists(patternsDir))) return [];

--- a/tools/mcp-server/test/server.test.mjs
+++ b/tools/mcp-server/test/server.test.mjs
@@ -19,6 +19,7 @@ import {
   loadSafetyDoc,
   listPatternDocs,
   loadPatternDoc,
+  loadGatePolicy,
 } from '../dist/resolver.js';
 
 let tmpRoot;
@@ -96,6 +97,19 @@ async function setup() {
   await writeFile(
     path.join(tmpRoot, 'docs', 'safety.md'),
     '# Safety\n\n## Path Denylists\n- .env\n- credentials\n',
+  );
+
+  // gate.yaml
+  await writeFile(
+    path.join(tmpRoot, 'gate.yaml'),
+    `version: 1
+denylist:
+  - ".env"
+  - "**/secrets/**"
+maxFiles: 10
+autoMergeAllowlist:
+  - "docs/**"
+`,
   );
 
   return tmpRoot;
@@ -296,6 +310,18 @@ test('loadSafetyDoc reads docs/safety.md', async () => {
   }
 });
 
+test('loadGatePolicy reads gate.yaml', async () => {
+  const root = await setup();
+  try {
+    const gate = await loadGatePolicy(root);
+    assert.ok(gate);
+    assert.ok(gate.includes('version: 1'));
+    assert.ok(gate.includes('.env'));
+  } finally {
+    await cleanup();
+  }
+});
+
 test('listPatternDocs finds .md files in patterns/', async () => {
   const root = await setup();
   try {
@@ -357,7 +383,7 @@ test('server lists all tools over stdio', async () => {
   try {
     const res = await callServer(root, [{ id: 1, method: 'tools/list', params: {} }]);
     const names = res.get(1).result.tools.map(t => t.name);
-    assert.equal(names.length, 8);
+    assert.equal(names.length, 9);
     assert.ok(names.includes('loop_list_patterns'));
     assert.ok(names.includes('loop_estimate_cost'));
   } finally {
@@ -404,6 +430,36 @@ test('pattern resource is readable over stdio', async () => {
     }]);
     const text = res.get(1).result.contents[0].text;
     assert.ok(text.includes('# Daily Triage'));
+  } finally {
+    await cleanup();
+  }
+});
+
+test('gate resource is readable over stdio', async () => {
+  const root = await setup();
+  try {
+    const res = await callServer(root, [{
+      id: 1, method: 'resources/read',
+      params: { uri: 'loop://gate' },
+    }]);
+    const text = res.get(1).result.contents[0].text;
+    assert.ok(text.includes('version: 1'));
+    assert.ok(text.includes('denylist:'));
+  } finally {
+    await cleanup();
+  }
+});
+
+test('loop_gate_check tool returns policy decision', async () => {
+  const root = await setup();
+  try {
+    const res = await callServer(root, [{
+      id: 1, method: 'tools/call',
+      params: { name: 'loop_gate_check', arguments: { action: 'commit', paths: ['.env', 'src/main.ts'] } },
+    }]);
+    const text = res.get(1).result.content[0].text;
+    assert.ok(text.includes('BLOCKED'));
+    assert.ok(text.includes('denylist'));
   } finally {
     await cleanup();
   }


### PR DESCRIPTION
## Summary
Expose the `loop-gate` policy checking logic as an MCP resource and tool within `mcp-server`, allowing MCP-connected agents to mechanically verify their intended changes against the static safety policy directly.

## Changes
- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example improvement
- [x] Tool change (`mcp-server` & `loop-gate`)
- [ ] Story (includes real failure or surprise + lesson)

## Checklist (from CONTRIBUTING)
- [x] All required sections present for patterns
- [x] Links work from README, patterns/README, starters/README, docs/index
- [x] No secrets, tokens, internal company URLs
- [x] `STATE.md*` examples use `.example` suffix
- [x] Safety-related content references `docs/safety.md`
- [x] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood
- [x] Added and passed new integration tests for `gate` resource and `loop_gate_check` tool in `mcp-server/test/server.test.mjs`.
- [x] `npm test` runs cleanly across the repository.

## Screenshots / Examples (if UI or command output)
Agents can now query `loop://gate` and call `loop_gate_check(action: 'commit', paths: ['...'])` without needing bash execution capabilities.