### PR TITLE
chore: scheduled maintenance — Jul 17 housekeeping

### DIFF
--- a/.github/workflows/release-loop-gate.yml
+++ b/.github/workflows/release-loop-gate.yml
@@ -1,0 +1,63 @@
+name: Release loop-gate
+
+on:
+  push:
+    tags:
+      - 'loop-gate-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. loop-gate-v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: tools/loop-gate/package-lock.json
+
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
+      - name: Install, build, test
+        working-directory: tools/loop-gate
+        run: |
+          npm ci
+          npm run build
+          npm test
+
+      - name: Skip if version already published
+        id: check
+        working-directory: tools/loop-gate
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@cobusgreyling/loop-gate@${VERSION}" version 2>/dev/null; then
+            echo "Version ${VERSION} already on npm — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing @cobusgreyling/loop-gate@${VERSION}"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        working-directory: tools/loop-gate
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,11 +2,11 @@
 
 Thank you to everyone who shipped docs, stories, examples, and tool fixes.
 
-*Generated 2026-07-16 via `node scripts/generate-contributors.mjs` — re-run after merges.*
+*Generated 2026-07-17 via `node scripts/generate-contributors.mjs` — re-run after merges.*
 
 | Contributor | Highlights |
 |-------------|------------|
-| [@KhaiTrang1995](https://github.com/KhaiTrang1995) | #274 feat(loop-worktree): add advisory path locking to prevent multi-loop collisions<br>#273 feat(loop-context): track daily token spend across runs, add --on-exceed hook |
+| [@KhaiTrang1995](https://github.com/KhaiTrang1995) | #291 feat(loop-gate): mechanical enforcement of the path denylist + auto-merge allowlist<br>#289 fix(build): drop chmod +x from build scripts, npm handles it on install |
 | [@k-anushka14](https://github.com/k-anushka14) | #249 Add Codeium (Windsurf) appendix to primitives matrix (#228)<br>#248 Add loop-init validation checklist (#231) |
 | [@Mahizhan-S](https://github.com/Mahizhan-S) | #251 docs: added Cursor Dependency Sweeper example #222<br>#217 docs: add npx quickstart for MCP server (#201) |
 | [@50thycal](https://github.com/50thycal) | story: `quant-loop-out-of-time.md`<br>story: `quant-loop-the-verifier-problem.md` |
@@ -23,6 +23,7 @@ Thank you to everyone who shipped docs, stories, examples, and tool fixes.
 | [@jiaobotao](https://github.com/jiaobotao) | #141 Add Hermes Agent example (daily-triage) + primitives matrix column |
 | [@KevinGuo1007](https://github.com/KevinGuo1007) | #206 docs: add Zed appendix to primitives matrix |
 | [@lorenzobosio](https://github.com/lorenzobosio) | #247 docs(examples): add Hermes PR Babysitter example |
+| [@THRISHAL12345](https://github.com/THRISHAL12345) | #296 feat(loop-context): add similarity-based stagnation detection |
 | [@Zhang-986](https://github.com/Zhang-986) | #138 fix(loop-sync): honor json output flag |
 
 ## Your first PR

--- a/RELEASE_NOTES_DRAFT.md
+++ b/RELEASE_NOTES_DRAFT.md
@@ -1,23 +1,34 @@
-# Release notes draft — since `loop-context-v1.2.0`
+# Release notes draft — since Discussion #294
 
-**Status:** Stub for next changelog-drafter run.
+**Status:** Stub for next changelog-drafter run / maintainer publish of `loop-gate`.
 
 **Last published:** [Discussion #294](https://github.com/cobusgreyling/loop-engineering/discussions/294) (2026-07-16) — `loop-context` 1.2.0, `loop-worktree` 1.1.0.
 
-**Window:** 2026-07-16 → (next tag)
+**Since then on npm:** `loop-worktree` **1.2.0**, `loop-context` **1.3.0** (tags live).
+
+**Window:** 2026-07-16 → (next community announcement)
 
 ---
 
 ## Highlights
 
-_(changelog-drafter will fill from merges since `loop-context-v1.2.0`)_
+### Shipped on npm
 
-### Pending npm publish
+| Package | What shipped |
+|---------|--------------|
+| `@cobusgreyling/loop-worktree` **1.2.0** | Wait queue (`--wait`) + deadlock detection on path locks ([#295](https://github.com/cobusgreyling/loop-engineering/pull/295) / #292, @THRISHAL12345) |
+| `@cobusgreyling/loop-context` **1.3.0** | Similarity-based stagnation detection ([#296](https://github.com/cobusgreyling/loop-engineering/pull/296), @THRISHAL12345) |
+
+### Pending first publish
 
 | Package | PR | What ships |
 |---------|-----|------------|
-| `@cobusgreyling/loop-worktree` **1.2.0** | [#292](https://github.com/cobusgreyling/loop-engineering/pull/292) | Wait queue (`--wait`) + deadlock detection on path locks (@THRISHAL12345) |
-| `@cobusgreyling/loop-gate` **1.0.0** | [#291](https://github.com/cobusgreyling/loop-engineering/pull/291) | Mechanical denylist + auto-merge allowlist from `gate.yaml` (@KhaiTrang1995) |
+| `@cobusgreyling/loop-gate` **1.0.0** | [#291](https://github.com/cobusgreyling/loop-engineering/pull/291) | Mechanical denylist + auto-merge allowlist from `gate.yaml` (@KhaiTrang1995). Release workflow: `release-loop-gate.yml`. |
+
+### Docs / community
+
+- Architecture diagrams ([#288](https://github.com/cobusgreyling/loop-engineering/pull/288))
+- Cross-platform build fix ([#289](https://github.com/cobusgreyling/loop-engineering/pull/289))
 
 ---
 
@@ -26,4 +37,6 @@ _(changelog-drafter will fill from merges since `loop-context-v1.2.0`)_
 ```bash
 npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok
 npx @cobusgreyling/loop-audit . --suggest
+# after gate publish:
+# npx @cobusgreyling/loop-gate check --action auto-merge --paths README.md
 ```

--- a/STATE.md
+++ b/STATE.md
@@ -1,11 +1,15 @@
 # Loop State — loop-engineering reference
 
-Last run: 2026-07-16T12:00:00Z (scheduled maintenance)
+Last run: 2026-07-17T06:55:00Z (scheduled maintenance)
 
 ## High Priority (loop is acting or waiting on human)
 
 - Maintain loop readiness score ≥ 58 (current: **100**, level **L3**).
-- npm publish in flight: `loop-worktree` 1.2.0, `loop-context` 1.3.0 (tags pushed this run). **`loop-gate` 1.0.0** still needs a `release-loop-gate.yml` workflow before first publish.
+- **First publish `loop-gate` 1.0.0**: release workflow added this run; after merge, tag `loop-gate-v1.0.0` and configure npm trusted publisher / `NPM_TOKEN`.
+- Review open contributor PRs (all CI green where applicable):
+  - [#303](https://github.com/cobusgreyling/loop-engineering/pull/303) — MCP `loop-gate` integration (@THRISHAL12345)
+  - [#302](https://github.com/cobusgreyling/loop-engineering/pull/302) — wire `loop-gate` into starter scripts (@THRISHAL12345)
+  - [#299](https://github.com/cobusgreyling/loop-engineering/pull/299) — loop-worktree week-two story; closes #229 (@k-anushka14)
 
 ## Watch List
 
@@ -13,17 +17,21 @@ Last run: 2026-07-16T12:00:00Z (scheduled maintenance)
 - Collect a production story for Post-Merge Cleanup.
 - Remaining Cursor doc gaps: [#220](https://github.com/cobusgreyling/loop-engineering/issues/220), [#223](https://github.com/cobusgreyling/loop-engineering/issues/223), [#224](https://github.com/cobusgreyling/loop-engineering/issues/224).
 - Validate `loop-init` scaffolds on fresh projects across all patterns.
+- Optional: stack-map notice [#300](https://github.com/cobusgreyling/loop-engineering/issues/300) (external listing).
 
-## Housekeeping (2026-07-16 maintenance)
+## Housekeeping (2026-07-17 maintenance)
 
-- Merged [#288](https://github.com/cobusgreyling/loop-engineering/pull/288) (architecture diagrams) and [#296](https://github.com/cobusgreyling/loop-engineering/pull/296) (loop-context similarity stagnation).
-- No open PRs; CI green on `main`.
-- Pruned stale remote branches (automated daily-triage, star-history, merged feature/fix branches).
-- Bumped `loop-context` to 1.3.0 for npm publish after #296.
+- Pulled `main` (star-history [#301](https://github.com/cobusgreyling/loop-engineering/pull/301)).
+- CI green on `main`; readiness audit **100 / L3**.
+- Confirmed npm live: `loop-worktree` 1.2.0, `loop-context` 1.3.0 (cleared prior “in flight” notes).
+- Added `release-loop-gate.yml` + documented in `docs/RELEASE.md`.
+- Regenerated `CONTRIBUTORS.md` (19 contributors); pruned run-log entries older than 30 days.
+- Refreshed `RELEASE_NOTES_DRAFT.md` for post-1.2.0/1.3.0 window.
 
 ## Recent Noise (ignored this run)
 
-—
+- Dependabot / star-history automation noise (merged routinely).
+- StackMap outreach issue #300 — marketing, not product work.
 
 ---
 Run log: Updated by `.github/workflows/daily-triage.yml`. See `LOOP.md` for cadence and gates.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release playbook — npm packages
 
-This repo ships eight public npm packages from `tools/`:
+This repo ships nine public npm packages from `tools/`:
 
 | Package | Directory | Release tag |
 |---------|-----------|-------------|
@@ -11,6 +11,7 @@ This repo ships eight public npm packages from `tools/`:
 | `@cobusgreyling/loop-context` | `tools/loop-context` | `loop-context-v*` |
 | `@cobusgreyling/loop-mcp-server` | `tools/mcp-server` | `loop-mcp-server-v*` |
 | `@cobusgreyling/loop-worktree` | `tools/loop-worktree` | `loop-worktree-v*` |
+| `@cobusgreyling/loop-gate` | `tools/loop-gate` | `loop-gate-v*` |
 | `@cobusgreyling/goal-audit` | `tools/goal-audit` | `goal-audit-v*` |
 
 ## One-time setup (trusted publishing — recommended)
@@ -26,6 +27,7 @@ Link npm to GitHub, then for **each package** on [npmjs.com](https://www.npmjs.c
 | `@cobusgreyling/loop-context` | `cobusgreyling/loop-engineering` | `release-loop-context.yml` |
 | `@cobusgreyling/loop-mcp-server` | `cobusgreyling/loop-engineering` | `release-loop-mcp-server.yml` |
 | `@cobusgreyling/loop-worktree` | `cobusgreyling/loop-engineering` | `release-loop-worktree.yml` |
+| `@cobusgreyling/loop-gate` | `cobusgreyling/loop-engineering` | `release-loop-gate.yml` |
 | `@cobusgreyling/goal-audit` | `cobusgreyling/loop-engineering` | `release-goal-audit.yml` |
 
 Names must match **exactly** (case-sensitive). No `NPM_TOKEN` secret is required when trusted publishing is configured.
@@ -73,12 +75,16 @@ git push origin loop-mcp-server-v1.0.0
 git tag loop-worktree-v1.0.0
 git push origin loop-worktree-v1.0.0
 
+# loop-gate (path denylist + auto-merge allowlist from gate.yaml)
+git tag loop-gate-v1.0.0
+git push origin loop-gate-v1.0.0
+
 # goal-audit (Goal Engineering readiness scorer — companion repo)
 git tag goal-audit-v1.0.2
 git push origin goal-audit-v1.0.2
 ```
 
-Workflows: `.github/workflows/release-loop-audit.yml`, `.github/workflows/release-loop-init.yml`, `.github/workflows/release-loop-cost.yml`, `.github/workflows/release-loop-sync.yml`, `.github/workflows/release-loop-context.yml`, `.github/workflows/release-loop-mcp-server.yml`, `.github/workflows/release-loop-worktree.yml`, `.github/workflows/release-goal-audit.yml`.
+Workflows: `.github/workflows/release-loop-audit.yml`, `.github/workflows/release-loop-init.yml`, `.github/workflows/release-loop-cost.yml`, `.github/workflows/release-loop-sync.yml`, `.github/workflows/release-loop-context.yml`, `.github/workflows/release-loop-mcp-server.yml`, `.github/workflows/release-loop-worktree.yml`, `.github/workflows/release-loop-gate.yml`, `.github/workflows/release-goal-audit.yml`.
 
 ## Verify after publish
 
@@ -90,6 +96,7 @@ npx @cobusgreyling/loop-sync --help
 npx @cobusgreyling/loop-context --help
 npx @cobusgreyling/loop-mcp-server --help
 npx @cobusgreyling/loop-worktree --help
+npx @cobusgreyling/loop-gate --help
 npx @cobusgreyling/goal-audit --help
 
 mkdir /tmp/loop-init-test && cd /tmp/loop-init-test

--- a/loop-run-log.md
+++ b/loop-run-log.md
@@ -21,7 +21,6 @@ Append one entry per run. Prune entries older than 30 days.
 
 <!-- Loop appends below this line -->
 
-{"run_id":"2026-06-16T12:43:13Z","pattern":"daily-triage","duration_s":10,"items_found":1,"actions_taken":1,"escalations":0,"tokens_estimate":52000,"readiness_score":100,"outcome":"report-only","workflow_run":"27618341632"}
 {"run_id":"2026-06-17T12:08:32Z","pattern":"daily-triage","duration_s":12,"items_found":1,"actions_taken":1,"escalations":0,"tokens_estimate":52000,"readiness_score":100,"outcome":"report-only","workflow_run":"27687793882"}
 {"run_id":"2026-06-18T11:41:06Z","pattern":"daily-triage","duration_s":8,"items_found":2,"actions_taken":1,"escalations":1,"tokens_estimate":52000,"readiness_score":100,"outcome":"escalated","workflow_run":"27756924361"}
 {"run_id":"2026-06-19T11:56:44Z","pattern":"daily-triage","duration_s":12,"items_found":1,"actions_taken":1,"escalations":0,"tokens_estimate":52000,"readiness_score":100,"outcome":"report-only","workflow_run":"27824250272"}
@@ -45,3 +44,4 @@ Append one entry per run. Prune entries older than 30 days.
 {"run_id":"2026-07-14T09:41:52Z","pattern":"daily-triage","duration_s":8,"items_found":1,"actions_taken":1,"escalations":0,"tokens_estimate":52000,"readiness_score":100,"outcome":"report-only","workflow_run":"29322649617"}
 {"run_id":"2026-07-15T09:44:51Z","pattern":"daily-triage","duration_s":9,"items_found":1,"actions_taken":1,"escalations":0,"tokens_estimate":52000,"readiness_score":100,"outcome":"report-only","workflow_run":"29405626165"}
 {"run_id":"2026-07-16T09:50:58Z","pattern":"daily-triage","duration_s":6,"items_found":1,"actions_taken":1,"escalations":0,"tokens_estimate":52000,"readiness_score":100,"outcome":"report-only","workflow_run":"29488647294"}
+{"run_id":"2026-07-17T06:55:00Z","pattern":"scheduled-maintenance","duration_s":900,"items_found":4,"actions_taken":3,"escalations":0,"tokens_estimate":80000,"readiness_score":100,"outcome":"fix-proposed"}


### PR DESCRIPTION
## Summary
Scheduled housekeeping for the loop-engineering reference repo.

- **Release path for `loop-gate`:** add `.github/workflows/release-loop-gate.yml` and document it in `docs/RELEASE.md` (first publish still needs tag `loop-gate-v1.0.0` + npm trusted publisher / `NPM_TOKEN`).
- **STATE.md:** clear in-flight notes for published `loop-context` 1.3.0 / `loop-worktree` 1.2.0; surface open PRs #299, #302, #303; keep loop-gate first-publish as high priority.
- **Hygiene:** regenerate `CONTRIBUTORS.md` (19), prune run-log entry older than 30 days, append maintenance run, refresh `RELEASE_NOTES_DRAFT.md`.
- Local readiness audit: **100 / L3**. CI green on `main` at start of run.

## Human gates after merge
1. Review/merge open contributor PRs when ready: #299 (story), #302 (starters), #303 (MCP gate).
2. Publish gate: `git tag loop-gate-v1.0.0 && git push origin loop-gate-v1.0.0` (after npm package trusted publisher is configured if using OIDC).

## Test plan
- [x] `node tools/loop-audit/dist/cli.js .` → 100/L3
- [x] `cd tools/loop-gate && npm test` → 31 pass
- [ ] CI validate + audit on this PR