### PR TITLE
ci: add release-loop-gate workflow

### DIFF
--- a/.github/workflows/release-loop-gate.yml
+++ b/.github/workflows/release-loop-gate.yml
@@ -1,0 +1,63 @@
+name: Release loop-gate
+
+on:
+  push:
+    tags:
+      - 'loop-gate-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. loop-gate-v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: tools/loop-gate/package-lock.json
+
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
+      - name: Install, build, test
+        working-directory: tools/loop-gate
+        run: |
+          npm ci
+          npm run build
+          npm test
+
+      - name: Skip if version already published
+        id: check
+        working-directory: tools/loop-gate
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@cobusgreyling/loop-gate@${VERSION}" version 2>/dev/null; then
+            echo "Version ${VERSION} already on npm — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing @cobusgreyling/loop-gate@${VERSION}"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        working-directory: tools/loop-gate
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/STATE.md
+++ b/STATE.md
@@ -5,7 +5,7 @@ Last run: 2026-07-16T12:00:00Z (scheduled maintenance)
 ## High Priority (loop is acting or waiting on human)
 
 - Maintain loop readiness score ≥ 58 (current: **100**, level **L3**).
-- npm publish in flight: `loop-worktree` 1.2.0, `loop-context` 1.3.0 (tags pushed this run). **`loop-gate` 1.0.0** still needs a `release-loop-gate.yml` workflow before first publish.
+- npm publish in flight: `loop-worktree` 1.2.0, `loop-context` 1.3.0 (tags pushed this run).
 
 ## Watch List
 


### PR DESCRIPTION
## Summary
Add `release-loop-gate.yml` workflow to enable publishing `@cobusgreyling/loop-gate` to npm.

## Changes
- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example improvement
- [x] Tool change (`loop-gate` release workflow)
- [ ] Story (includes real failure or surprise + lesson)

## Checklist (from CONTRIBUTING)
- [x] All required sections present for patterns
- [x] Links work from README, patterns/README, starters/README, docs/index
- [x] No secrets, tokens, internal company URLs
- [x] `STATE.md*` examples use `.example` suffix
- [x] Safety-related content references `docs/safety.md`
- [x] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood
- Added `release-loop-gate.yml` following the established working patterns (e.g., `release-loop-worktree.yml`).

## Screenshots / Examples (if UI or command output)
Closes the open TODO in `STATE.md`.