### PR TITLE
fix: remove duplicate state scan, dead safety fallback, and align MCP cost ratios

### DIFF
--- a/tools/loop-audit/src/auditor.ts
+++ b/tools/loop-audit/src/auditor.ts
@@ -210,7 +210,7 @@ async function findSkills(root: string): Promise<string[]> {
 
 async function detectLoopActivity(root: string): Promise<{ present: boolean; evidence: string[] }> {
   const evidence: string[] = [];
-  const stateCandidates = [...STATE_FILES, 'STATE.md'];
+  const stateCandidates = [...STATE_FILES];
 
   // 1. Look for "Last run" timestamps or dated entries inside state files (strong real-usage signal)
   for (const sf of stateCandidates) {
@@ -374,9 +374,6 @@ export async function auditProject(target: string): Promise<AuditResult> {
   let safetyDocPresent = false;
   for (const f of SAFETY_FILES) {
     if (await fileExists(path.join(root, f))) { safetyDocPresent = true; break; }
-  }
-  if (!safetyDocPresent) {
-    safetyDocPresent = await fileExists(path.join(root, 'docs', 'safety.md'));
   }
 
   const mcpPresent = (await Promise.all(MCP_FILES.map(f => fileExists(path.join(root, f))))).some(Boolean) ||

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -392,9 +392,9 @@ server.tool(
 
     const { cost } = pattern;
     const mix = level === 'L1'
-      ? { noop: 0.7, report: 0.3, action: 0 }
+      ? { noop: 0.6, report: 0.4, action: 0 }
       : level === 'L2'
-        ? { noop: 0.6, report: 0.25, action: 0.15 }
+        ? { noop: 0.5, report: 0.3, action: 0.2 }
         : { noop: 0.4, report: 0.35, action: 0.25 };
 
     const realisticPerRun = cost.tokens_noop * mix.noop


### PR DESCRIPTION
## Summary

- **Remove duplicate `STATE.md` in `stateCandidates`**: `STATE_FILES` already includes `'STATE.md'`, so spreading it and appending `'STATE.md'` again caused the file to be scanned twice. Changed to just `[...STATE_FILES]`.

- **Remove dead safety doc fallback**: `SAFETY_FILES` already contains `'docs/safety.md'`, so the fallback check `await fileExists(path.join(root, 'docs', 'safety.md'))` after iterating `SAFETY_FILES` was unreachable dead code. Removed the redundant block.

- **Align MCP server cost mix ratios with the canonical estimator**: The hardcoded mix ratios in the MCP server's cost estimate tool diverged from `realisticMix()` in `tools/loop-cost/src/estimator.ts`. Updated L1 from `noop: 0.7, report: 0.3` to `noop: 0.6, report: 0.4`, and L2 from `noop: 0.6, report: 0.25, action: 0.15` to `noop: 0.5, report: 0.3, action: 0.2` to match the estimator's canonical non-early-exit values.

## Test plan

- [ ] Verify `stateCandidates` no longer contains duplicate `STATE.md` entries
- [ ] Confirm safety doc detection still works correctly via the `SAFETY_FILES` loop
- [ ] Confirm MCP server cost estimates now match the standalone estimator for L1 and L2 levels