### PR TITLE
fix(release): build loop-gate before mcp-server publish tests

### DIFF
--- a/.github/workflows/release-loop-mcp-server.yml
+++ b/.github/workflows/release-loop-mcp-server.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Ensure npm supports trusted publishing (OIDC)
         run: npm install -g npm@latest
 
+      - name: Build loop-gate sibling (file: dependency)
+        working-directory: tools/loop-gate
+        run: |
+          npm ci
+          npm run build
+
       - name: Install, build, test
         working-directory: tools/mcp-server
         run: |


### PR DESCRIPTION
mcp-server 1.1.0 release failed: gate resource tests timeout because `file:../loop-gate` has no built `dist/`. Mirror the loop-context/loop-cost pattern.