### PR TITLE
fix(release): unbreak release-loop-mcp-server YAML

### DIFF
--- a/.github/workflows/release-loop-mcp-server.yml
+++ b/.github/workflows/release-loop-mcp-server.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Ensure npm supports trusted publishing (OIDC)
         run: npm install -g npm@latest
 
-      - name: Build loop-gate sibling (file: dependency)
+      - name: Build loop-gate sibling (file dependency)
         working-directory: tools/loop-gate
         run: |
           npm ci


### PR DESCRIPTION
Step name `file: dependency` is invalid YAML (colon). Blocks all mcp-server release runs.