### PR TITLE
Wire loop-context circuit breaker into fix-capable patterns

### DIFF
--- a/examples/github-actions/ci-sweeper.yml
+++ b/examples/github-actions/ci-sweeper.yml
@@ -37,7 +37,21 @@ jobs:
           echo "- URL: ${{ github.event.workflow_run.html_url }}" >> "$FILE"
           echo "- Loop action: pending agent invocation" >> "$FILE"
 
+      - name: Circuit breaker check
+        id: circuit_breaker
+        run: |
+          npx --yes @cobusgreyling/loop-context --check --ledger loop-ledger.json \
+            --budget-from-pattern ci-sweeper --budget-level L2 || echo "tripped=true" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
       - name: Invoke fix agent
+        if: steps.circuit_breaker.outputs.tripped != 'true'
         run: |
           echo "::notice::Wire to agent: classify failure, worktree fix, verifier, open PR."
           echo "See patterns/ci-sweeper.md and docs/safety.md"
+
+      - name: Escalate (circuit breaker tripped)
+        if: steps.circuit_breaker.outputs.tripped == 'true'
+        run: |
+          echo "::warning::Circuit breaker tripped — same failure recurred or attempt cap reached."
+          echo "Escalating to human instead of retrying. See docs/safety.md#human-gates-required."

--- a/examples/github-actions/dependency-sweeper.yml
+++ b/examples/github-actions/dependency-sweeper.yml
@@ -18,8 +18,21 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Circuit breaker check
+        id: circuit_breaker
+        run: |
+          npx --yes @cobusgreyling/loop-context --check --ledger loop-ledger.json \
+            --budget-from-pattern dependency-sweeper --budget-level L2 || echo "tripped=true" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
       - name: Placeholder — wire to your agent runtime
+        if: steps.circuit_breaker.outputs.tripped != 'true'
         run: |
           echo "Run dependency-triage (npm audit / outdated)."
           echo "Patch-only fixes in worktree with verifier."
           echo "Update dependency-sweeper-state.md — escalate majors."
+
+      - name: Escalate (circuit breaker tripped)
+        if: steps.circuit_breaker.outputs.tripped == 'true'
+        run: |
+          echo "::warning::Circuit breaker tripped for this package — see docs/safety.md#human-gates-required."

--- a/patterns/dependency-sweeper.md
+++ b/patterns/dependency-sweeper.md
@@ -43,6 +43,21 @@ Prune merged/closed entries on every run.
 6. Update the state file and (optionally) comment on open dependency PRs.
 7. On next run, re-evaluate open items and close stale or conflicting ones.
 
+## Circuit Breaker
+
+This is a fix-capable (L2) pattern, so `loop-init` scaffolds the `loop-guard` skill and a seeded `loop-ledger.json` for it automatically. Before each retry on the same package, run the circuit breaker:
+
+```bash
+npx @cobusgreyling/loop-context --check --ledger loop-ledger.json \
+  --budget-from-pattern dependency-sweeper --budget-level L2
+```
+
+If the same failure recurs or the attempt cap is hit (see "Escalate after 2
+tries" below), it exits non-zero — stop retrying and escalate to a human
+instead of looping. See [docs/safety.md](../docs/safety.md).
+
+
+
 ## Verification Strategy
 
 - **Never** let the implementer sub-agent declare success.

--- a/patterns/post-merge-cleanup.md
+++ b/patterns/post-merge-cleanup.md
@@ -50,6 +50,18 @@ Last run: 2026-06-09 22:00 UTC
 6. Open small PRs or batch into a single "cleanup" PR per day.
 7. Update state; prune completed items.
 
+## Circuit Breaker
+
+This is a fix-capable (L2) pattern, so `loop-init` scaffolds the `loop-guard` skill and a seeded `loop-ledger.json` for it automatically. Run the circuit breaker before each retry on the same regression:
+
+```bash
+npx @cobusgreyling/loop-context --check --ledger loop-ledger.json \
+  --budget-from-pattern post-merge-cleanup --budget-level L2
+```
+
+Non-zero exit means the same failure repeated or the attempt cap was hit —
+stop and escalate to a human. See [docs/safety.md](../docs/safety.md).
+
 ## Verification Strategy
 
 - Cleanup must not alter behavior unless explicitly removing dead code paths.

--- a/patterns/pr-babysitter.md
+++ b/patterns/pr-babysitter.md
@@ -44,6 +44,20 @@ Example state entry:
 4. Write concise updates back to the PR and to state.
 5. Anything ambiguous or high-risk → surface to human with context.
 
+## Circuit Breaker
+
+This is a fix-capable (L2) pattern, so `loop-init` scaffolds the `loop-guard` skill and a seeded `loop-ledger.json` for it automatically. Run the circuit breaker before each retry attempt on a watched PR:
+
+```bash
+npx @cobusgreyling/loop-context --check --ledger loop-ledger.json \
+  --budget-from-pattern pr-babysitter --budget-level L2
+```
+
+Non-zero exit means the same failure repeated or the attempt cap was hit —
+stop and escalate to a human instead of continuing to comment/retry on the
+PR. See [docs/safety.md](../docs/safety.md).
+
+
 ## Verification Strategy
 
 - Never let the implementer sub-agent mark its own work "done".

--- a/starters/dependency-sweeper/README.md
+++ b/starters/dependency-sweeper/README.md
@@ -24,7 +24,7 @@ Claude Code / Codex: use `--tool claude` or `--tool codex` with `loop-init`.
 Start (Grok):
 
 ```
-/loop 6h Run dependency-triage on package manifests and lockfiles. Patch-only auto-fix in worktree + verifier (npm ci && npm test). Run loop-gate check before commit. Escalate majors, high-sev CVEs, and denylist packages. Update dependency-sweeper-state.md.
+/loop 6h Run dependency-triage on package manifests and lockfiles. Patch-only auto-fix in worktree + verifier (npm ci && npm test). Run loop-context --check before each retry on the same package; run loop-gate check before commit. Escalate majors, high-sev CVEs, and denylist packages after 2 attempts. Update dependency-sweeper-state.md.
 ```
 
 ## What's Included

--- a/starters/post-merge-cleanup/README.md
+++ b/starters/post-merge-cleanup/README.md
@@ -17,7 +17,7 @@ cp starters/post-merge-cleanup/LOOP.md .
 Start (Grok):
 
 ```
-/loop 1d Run post-merge-scan on merges to main (last 7d). Update post-merge-state.md. Small doc/link fixes only in worktree. Run loop-gate check before commit. Escalate refactors.
+/loop 1d Run post-merge-scan on merges to main (last 7d). Update post-merge-state.md. Small doc/link fixes only in worktree. Run loop-context --check before each retry on the same regression; run loop-gate check before commit. Escalate refactors.
 ```
 
 ## Files

--- a/starters/pr-babysitter/README.md
+++ b/starters/pr-babysitter/README.md
@@ -17,7 +17,7 @@ Scaffold for the [PR Babysitter](../../patterns/pr-babysitter.md) loop (L2 — a
 
 3. Start (Grok):
    ```bash
-   /loop 5m Check open PRs. Update pr-babysitter-state.md. For CI failures or actionable review comments on allowlisted PRs: worktree + minimal-fix + loop-verifier. Run loop-gate check before commit. Never merge — propose only. Escalate after 3 attempts per PR.
+   /loop 5m Check open PRs. Update pr-babysitter-state.md. For CI failures or actionable review comments on allowlisted PRs: worktree + minimal-fix + loop-verifier. Run loop-context --check before each retry; run loop-gate check before commit. Never merge — propose only. Escalate after 3 attempts per PR.
    ```
 
 4. Sign PR comments: `🤖 Loop Engineering — PR Babysitter`


### PR DESCRIPTION
## Problem

`loop-context` is the circuit breaker meant to stop infinite/stagnant retry
loops (iteration cap, stagnation detection, token budget). `loop-init`
already scaffolds it (the `loop-guard` skill + a seeded `loop-ledger.json`)
for every fix-capable pattern (`ci-sweeper`, `pr-babysitter`,
`dependency-sweeper`, `post-merge-cleanup`), and even prints the exact
command to run after scaffolding.

But nothing downstream actually tells the agent to call it. Compare to
`loop-gate` (the path denylist / auto-merge guardrail), which every
fix-capable starter's `/loop` prompt explicitly instructs the agent to run
before committing. `loop-context` gets no equivalent treatment:

- Only `patterns/ci-sweeper.md` documents the circuit breaker — the other
  3 fix-capable patterns (`dependency-sweeper.md`, `pr-babysitter.md`,
  `post-merge-cleanup.md`) don't mention it at all.
- No starter's `/loop` prompt tells the agent to run
  `loop-context --check` before retrying, even though they all explicitly
  say to run `loop-gate check` before committing.
- The `ci-sweeper.yml` and `dependency-sweeper.yml` GitHub Actions
  examples — the reference automations most likely to be copied into a
  real repo — never call the circuit breaker; the "invoke fix agent" step
  is a bare placeholder with no mechanical check gating it.

This matches `docs/safety.md`'s own stated design principle for
`loop-gate` ("enforces this denylist... mechanically... instead of
relying on the loop to have read this file") — but `loop-context` doesn't
currently meet that bar.

## Fix

- Added a "Circuit Breaker" section to the 3 pattern docs that were
  missing it, matching the section already in `ci-sweeper.md`, linking
  to `docs/safety.md`.
- Added the explicit `loop-context --check` instruction to the affected
  starter `/loop` prompts, alongside the existing `loop-gate check`
  instruction.
- Added a `loop-context --check` step to the `ci-sweeper.yml` and
  `dependency-sweeper.yml` GitHub Actions examples that gates the fix
  step and escalates instead of retrying when tripped.

## Checklist
- [x] Links work from README or relevant index
- [x] No secrets, tokens, or internal URLs
- [x] Safety-sensitive patterns reference `docs/safety.md`