### PR TITLE
chore: scheduled maintenance — goal-init release, loop-context 1.4.0

### DIFF
--- a/.github/workflows/release-goal-init.yml
+++ b/.github/workflows/release-goal-init.yml
@@ -1,0 +1,63 @@
+name: Release goal-init
+
+on:
+  push:
+    tags:
+      - 'goal-init-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. goal-init-v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: tools/goal-init/package-lock.json
+
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
+      - name: Install, build, test
+        working-directory: tools/goal-init
+        run: |
+          npm ci
+          npm run build
+          npm test
+
+      - name: Skip if version already published
+        id: check
+        working-directory: tools/goal-init
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@cobusgreyling/goal-init@${VERSION}" version 2>/dev/null; then
+            echo "Version ${VERSION} already on npm — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing @cobusgreyling/goal-init@${VERSION}"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        working-directory: tools/goal-init
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/STATE.md
+++ b/STATE.md
@@ -1,19 +1,12 @@
 # Loop State — loop-engineering reference
 
-Last run: 2026-07-21T14:11:50Z (PR triage / scheduled maintenance)
+Last run: 2026-07-21T20:30:00Z (scheduled maintenance)
 
 ## High Priority (loop is acting or waiting on human)
 
-- Maintain loop readiness score ≥ 58 (current: **100**, level **L3**). Harness-runtime warn: no `.foundry/stack.yaml` — optional dogfood `loop-init --with-foundry` (human).
-- **Shipped (recent):** [#324](https://github.com/cobusgreyling/loop-engineering/pull/324) Foundry funnel + [v1.6.0](https://github.com/cobusgreyling/loop-engineering/releases/tag/v1.6.0); ecosystem/docs/star-history automation; **triage 2026-07-21:**
-  - Merged [#335](https://github.com/cobusgreyling/loop-engineering/pull/335) loop-context circuit breaker wiring (@Tusm11)
-  - Merged [#318](https://github.com/cobusgreyling/loop-engineering/pull/318) live telemetry on docs site (@THRISHAL12345)
-  - Merged [#316](https://github.com/cobusgreyling/loop-engineering/pull/316) loop-sync requiredFiles (+ dropped accidental `pr-description.md`)
-  - Closed [#315](https://github.com/cobusgreyling/loop-engineering/pull/315) superseded housekeeping draft
-- **Waiting on author (changes requested):**
-  - [#317](https://github.com/cobusgreyling/loop-engineering/pull/317) goal-init — strip `.test-manual/`, `scratch.js`, `PR_DESCRIPTION.md`, unrelated `dist/`
-  - [#321](https://github.com/cobusgreyling/loop-engineering/pull/321) readiness-core — rebase (conflicts), strip noise dist, add tests, clarify private vs publish
-- Issues: [#332](https://github.com/cobusgreyling/loop-engineering/issues/332) release prep · [#320](https://github.com/cobusgreyling/loop-engineering/issues/320) weekly report
+- Maintain loop readiness score ≥ 58 (current: **100**, level **L3**).
+- npm publish in flight this run: `readiness-core` 1.0.0, `goal-init` 1.0.0, `loop-context` 1.4.0 (tags after merge).
+- [#332](https://github.com/cobusgreyling/loop-engineering/issues/332) release prep — week of 2026-07-20 (human changelog/discussion).
 
 ## Watch List
 
@@ -22,20 +15,24 @@ Last run: 2026-07-21T14:11:50Z (PR triage / scheduled maintenance)
 - Validate `loop-init --with-foundry` on fresh projects
 - Optional: StackMap #300, Pluribus #262, loop.js #246
 
-## Housekeeping (2026-07-21 triage)
+## Housekeeping (2026-07-21 scheduled maintenance)
 
-- Human PR triage completed (merge 316/318/335; close 315; CHANGES_REQUESTED 317/321).
-- Main CI green; readiness 100/L3; npm current as of last release prep.
+- Merged [#338](https://github.com/cobusgreyling/loop-engineering/pull/338) (loop-init lockfile → loop-audit 1.7.0).
+- Merged [#337](https://github.com/cobusgreyling/loop-engineering/pull/337) (loop-context frustration circuit breaker) — bumped to 1.4.0.
+- Added `release-goal-init.yml` + RELEASE.md docs; first publish for `goal-init` + `readiness-core`.
+- Closed draft [#336](https://github.com/cobusgreyling/loop-engineering/pull/336) as superseded.
+- Closed weekly loop report [#320](https://github.com/cobusgreyling/loop-engineering/issues/320) after review.
+- No open PRs after this run; CI green on `main`.
 
 ## Recent Noise
 
-- Star-history / sparse automated STATE overwrite (expected).
-- Automated daily-triage can clobber curated High Priority — re-curate after merge.
+- Star-history / dependabot automation (routine).
+- StackMap #300 marketing.
 
 ## Post-Run Critique
 
-- Friction: automated daily-triage still overwrites curated STATE.
-- Adjustment: land curated maintenance after triage; consider workflow preserve-section later.
+- Friction: `goal-init` landed without a release workflow; caught on maintenance.
+- Adjustment: require release workflow + RELEASE.md row in the same PR as any new `tools/*` package.
 
 ---
-Run log: Updated by daily-triage.yml and scheduled maintenance. See LOOP.md.
+Run log: Updated by `.github/workflows/daily-triage.yml`. See `LOOP.md` for cadence and gates.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release playbook — npm packages
 
-This repo ships ten public npm packages from `tools/`:
+This repo ships eleven public npm packages from `tools/`:
 
 | Package | Directory | Release tag |
 |---------|-----------|-------------|
@@ -14,6 +14,7 @@ This repo ships ten public npm packages from `tools/`:
 | `@cobusgreyling/loop-worktree` | `tools/loop-worktree` | `loop-worktree-v*` |
 | `@cobusgreyling/loop-gate` | `tools/loop-gate` | `loop-gate-v*` |
 | `@cobusgreyling/goal-audit` | `tools/goal-audit` | `goal-audit-v*` |
+| `@cobusgreyling/goal-init` | `tools/goal-init` | `goal-init-v*` |
 
 ## One-time setup (trusted publishing — recommended)
 
@@ -31,6 +32,7 @@ Link npm to GitHub, then for **each package** on [npmjs.com](https://www.npmjs.c
 | `@cobusgreyling/loop-worktree` | `cobusgreyling/loop-engineering` | `release-loop-worktree.yml` |
 | `@cobusgreyling/loop-gate` | `cobusgreyling/loop-engineering` | `release-loop-gate.yml` |
 | `@cobusgreyling/goal-audit` | `cobusgreyling/loop-engineering` | `release-goal-audit.yml` |
+| `@cobusgreyling/goal-init` | `cobusgreyling/loop-engineering` | `release-goal-init.yml` |
 
 Names must match **exactly** (case-sensitive). No `NPM_TOKEN` secret is required when trusted publishing is configured.
 
@@ -88,9 +90,13 @@ git push origin loop-gate-v1.0.0
 # goal-audit (Goal Engineering readiness scorer — companion repo)
 git tag goal-audit-v1.0.2
 git push origin goal-audit-v1.0.2
+
+# goal-init (scaffold goal engineering setups)
+git tag goal-init-v1.0.0
+git push origin goal-init-v1.0.0
 ```
 
-Workflows: `.github/workflows/release-readiness-core.yml`, `.github/workflows/release-loop-audit.yml`, `.github/workflows/release-loop-init.yml`, `.github/workflows/release-loop-cost.yml`, `.github/workflows/release-loop-sync.yml`, `.github/workflows/release-loop-context.yml`, `.github/workflows/release-loop-mcp-server.yml`, `.github/workflows/release-loop-worktree.yml`, `.github/workflows/release-loop-gate.yml`, `.github/workflows/release-goal-audit.yml`.
+Workflows: `.github/workflows/release-readiness-core.yml`, `.github/workflows/release-loop-audit.yml`, `.github/workflows/release-loop-init.yml`, `.github/workflows/release-loop-cost.yml`, `.github/workflows/release-loop-sync.yml`, `.github/workflows/release-loop-context.yml`, `.github/workflows/release-loop-mcp-server.yml`, `.github/workflows/release-loop-worktree.yml`, `.github/workflows/release-loop-gate.yml`, `.github/workflows/release-goal-audit.yml`, `.github/workflows/release-goal-init.yml`.
 
 ## Verify after publish
 

--- a/tools/loop-context/package.json
+++ b/tools/loop-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobusgreyling/loop-context",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Stateful memory manager for agent loops — summarize, prune, and inject context, with a circuit breaker that escalates stagnant or no-progress runs instead of burning tokens.",
   "type": "module",
   "main": "dist/context-manager.js",


### PR DESCRIPTION
## Scheduled maintenance 2026-07-21

- Merged earlier: #338 (dependabot lockfile), #337 (frustration breaker)
- Add `release-goal-init.yml` + RELEASE.md (first publish for goal-init)
- Bump `loop-context` → 1.4.0
- STATE.md refresh

After merge: tag `readiness-core-v1.0.0`, `goal-init-v1.0.0`, `loop-context-v1.4.0`.