### PR TITLE
Add caching budget scenario to loop-context

### DIFF
--- a/tools/loop-context/src/budget-resolver.ts
+++ b/tools/loop-context/src/budget-resolver.ts
@@ -6,9 +6,9 @@ import { spawn } from 'node:child_process';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 
-export type BudgetScenario = 'realistic' | 'action' | 'report';
+export type BudgetScenario = 'realistic' | 'action' | 'report' | 'caching';
 
-export const VALID_BUDGET_SCENARIOS: BudgetScenario[] = ['realistic', 'action', 'report'];
+export const VALID_BUDGET_SCENARIOS: BudgetScenario[] = ['realistic', 'action', 'report', 'caching'];
 
 export function assertValidBudgetScenario(scenario: string): asserts scenario is BudgetScenario {
   if (!VALID_BUDGET_SCENARIOS.includes(scenario as BudgetScenario)) {
@@ -82,6 +82,7 @@ async function invokeLoopCost(input: BudgetFromPatternInput): Promise<LoopCostRe
   const args = ['--pattern', input.pattern, '--level', input.level ?? 'L1'];
   if (input.cadence) args.push('--cadence', input.cadence);
   if (input.conservative) args.push('--conservative');
+  if (input.scenario === 'caching') args.push('--with-caching');
 
   const { stdout, stderr, code } = await runCostCli(cli, args);
   if (code !== 0) {
@@ -109,7 +110,11 @@ export async function resolveTokenBudgetFromPattern(input: BudgetFromPatternInpu
   const parsed = await invokeLoopCost(input);
   const tokensPerRun = parsed.scenarios?.[scenario]?.tokensPerRun;
   if (typeof tokensPerRun !== 'number') {
-    throw new Error(`loop-cost output missing scenarios.${scenario}.tokensPerRun.`);
+    const hint =
+      scenario === 'caching'
+        ? ' This pattern may be missing stable_fraction in registry.yaml.'
+        : '';
+    throw new Error(`loop-cost output missing scenarios.${scenario}.tokensPerRun.${hint}`);
   }
   return tokensPerRun;
 }

--- a/tools/loop-context/src/cli.ts
+++ b/tools/loop-context/src/cli.ts
@@ -172,8 +172,10 @@ Options:
                             estimate instead of typing a number. Ignored if
                             --token-budget is also given (explicit wins).
   --budget-level <L1|L2|L3> Readiness level for --budget-from-pattern (default: L1)
-  --budget-scenario <realistic|action|report>
-                            Which loop-cost scenario to use (default: realistic)
+  --budget-scenario <realistic|action|report|caching>
+                            Which loop-cost scenario to use (default: realistic).
+                            caching requires stable_fraction set on the pattern
+                            in registry.yaml (see loop-cost --with-caching).
   --budget-cadence <spec>   Cadence override passed through to loop-cost
   --budget-conservative     Use the slower cadence in a range (loop-cost flag)
   --daily-budget-from-pattern <id>


### PR DESCRIPTION
## Problem

loop-cost's `--with-caching` flag reports a discounted `caching`
scenario, but `loop-context --budget-from-pattern` (which resolves a
token budget by shelling out to loop-cost) had no way to request it —
`--budget-scenario` only accepted `realistic`, `action`, or `report`.
Anyone using prompt caching had no way to set a circuit-breaker budget
that reflects their actual discounted spend.

## Fix

- Add `'caching'` as a valid `--budget-scenario` value.
- Pass `--with-caching` through to loop-cost automatically when that
  scenario is selected.
- Give a specific error message (pointing at `stable_fraction` in
  `registry.yaml`) when a pattern doesn't support the caching scenario
  yet, instead of a generic "missing tokensPerRun" error.
- Update `--help` text accordingly.

No changes to the ledger/circuit-breaker logic itself — this is scoped
to budget resolution only.

**Depends on:** #346 (adds `stable_fraction` and `--with-caching` to
loop-cost) — should be merged first, or reviewed together.

## Checklist
- [x] Links work from README or relevant index
- [x] No secrets, tokens, or internal URLs