### PR TITLE
fix(ci): build readiness-core before loop-audit in daily-triage

### DIFF
--- a/.github/workflows/daily-triage.yml
+++ b/.github/workflows/daily-triage.yml
@@ -25,10 +25,14 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-          cache-dependency-path: tools/loop-audit/package-lock.json
+          cache-dependency-path: |
+            tools/readiness-core/package-lock.json
+            tools/loop-audit/package-lock.json
 
-      - name: Build loop-audit
+      - name: Build readiness-core + loop-audit
         run: |
+          # loop-audit depends on file:../readiness-core after #321
+          (cd tools/readiness-core && npm ci && npm run build)
           cd tools/loop-audit
           npm ci
           npm run build


### PR DESCRIPTION
## Problem
[Daily Triage dogfood](https://github.com/cobusgreyling/loop-engineering/actions/runs/29905417836) failed 2026-07-22:

```
error TS2307: Cannot find module '@cobusgreyling/readiness-core'
```

After #321, `loop-audit` imports `@cobusgreyling/readiness-core` via `file:../readiness-core`. The daily-triage workflow only ran `npm ci && npm run build` in `tools/loop-audit`.

## Fix
Build readiness-core first (same as `release-loop-audit.yml` / `ci-audit-gates.sh`), and cache both lockfiles.

## Test plan
- [x] Diff matches release-loop-audit install order
- [ ] Merge then `workflow_dispatch` Daily Triage