### PR TITLE
fix(ci): isolate audit and validation gate temp files

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,18 +25,22 @@ jobs:
           cache-dependency-path: tools/loop-audit/package-lock.json
 
       - name: Build, test & run loop-audit on the reference + starters
+        env:
+          LOOP_AUDIT_OUTPUT_FILE: ${{ runner.temp }}/audit.json
         run: bash scripts/ci-audit-gates.sh
 
       - name: Comment PR with loop readiness score
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
+        env:
+          LOOP_AUDIT_OUTPUT_FILE: ${{ runner.temp }}/audit.json
         uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
             let data;
             try {
-              data = JSON.parse(fs.readFileSync('/tmp/audit.json', 'utf8'));
+              data = JSON.parse(fs.readFileSync(process.env.LOOP_AUDIT_OUTPUT_FILE, 'utf8'));
             } catch (e) {
               core.setFailed('Could not read audit JSON for PR comment');
               return;

--- a/scripts/ci-audit-gates.sh
+++ b/scripts/ci-audit-gates.sh
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+AUDIT_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/loop-engineering-audit.XXXXXX")"
+trap 'rm -rf "$AUDIT_TMP_DIR"' EXIT
+ROOT_AUDIT_FILE="$AUDIT_TMP_DIR/root-audit.json"
 
 echo "Building readiness-core…"
 (
@@ -15,35 +18,41 @@ cd "$REPO_ROOT/tools/loop-audit"
 npm ci
 npm test
 echo "=== Audit of repo root ==="
-node dist/cli.js "$REPO_ROOT" --json > /tmp/root-audit.json
+node dist/cli.js "$REPO_ROOT" --json > "$ROOT_AUDIT_FILE"
 echo ""
 echo "=== Audit of starters (L1 gate) ==="
 FAILED=0
 for s in "$REPO_ROOT"/starters/*/; do
   NAME=$(basename "$s")
-  node dist/cli.js "$s" --json > "/tmp/starter-${NAME}.json"
-  node -e "
-    const data = JSON.parse(require('fs').readFileSync('/tmp/starter-${NAME}.json', 'utf8'));
-    console.log('--- ${NAME}: score=' + data.score + ' level=' + data.level);
+  STARTER_AUDIT_FILE="$AUDIT_TMP_DIR/starter-${NAME}.json"
+  node dist/cli.js "$s" --json > "$STARTER_AUDIT_FILE"
+  STARTER_AUDIT_FILE="$STARTER_AUDIT_FILE" STARTER_NAME="$NAME" node -e '
+    const fs = require("fs");
+    const data = JSON.parse(fs.readFileSync(process.env.STARTER_AUDIT_FILE, "utf8"));
+    console.log("--- " + process.env.STARTER_NAME + ": score=" + data.score + " level=" + data.level);
     if (data.score < 38) {
-      console.error('Starter ${NAME} below L1 threshold (38): ' + data.score);
+      console.error("Starter " + process.env.STARTER_NAME + " below L1 threshold (38): " + data.score);
       process.exit(1);
     }
-  " || FAILED=1
+  ' || FAILED=1
 done
 if [ "$FAILED" -ne 0 ]; then
   echo "One or more starters failed L1 gate"
   exit 1
 fi
-cp /tmp/root-audit.json /tmp/audit.json
 
-node -e '
+ROOT_AUDIT_FILE="$ROOT_AUDIT_FILE" node -e '
   const fs = require("fs");
-  const data = JSON.parse(fs.readFileSync("/tmp/audit.json", "utf8"));
+  const data = JSON.parse(fs.readFileSync(process.env.ROOT_AUDIT_FILE, "utf8"));
   console.log("Reference score: " + data.score);
   if (data.score < 58) {
     console.error("Reference score below L2 threshold (58). Restore dogfood signals: STATE.md, skills/, AGENTS.md.");
     process.exit(2);
   }
 '
+
+if [[ -n "${LOOP_AUDIT_OUTPUT_FILE:-}" ]]; then
+  cp "$ROOT_AUDIT_FILE" "$LOOP_AUDIT_OUTPUT_FILE"
+fi
+
 echo "audit gates passed ✓"

--- a/scripts/ci-validate-gates.sh
+++ b/scripts/ci-validate-gates.sh
@@ -2,14 +2,19 @@
 # Pattern/registry validation gates — shared by validate-patterns.yml and daily-triage.yml
 set -euo pipefail
 
+VALIDATE_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/loop-engineering-validate.XXXXXX")"
+trap 'rm -rf "$VALIDATE_TMP_DIR"' EXIT
+REGISTRY_FILE="$VALIDATE_TMP_DIR/registry.txt"
+PATTERN_FILES="$VALIDATE_TMP_DIR/files.txt"
+
 echo "Patterns declared in registry:"
-grep '^\s*-\s*id:' patterns/registry.yaml | sed 's/.*id: //' | sort > /tmp/registry.txt
+grep '^\s*-\s*id:' patterns/registry.yaml | sed 's/.*id: //' | sort > "$REGISTRY_FILE"
 echo "Pattern markdown files:"
-ls patterns/*.md | xargs -n1 basename | sed 's/.md$//' | grep -v README | sort > /tmp/files.txt
-echo "=== Registry ==="; cat /tmp/registry.txt
-echo "=== Files ==="; cat /tmp/files.txt
-comm -23 /tmp/files.txt /tmp/registry.txt | grep . && (echo "ERROR: pattern md file(s) missing from registry.yaml"; exit 1) || echo "All pattern files registered ✓"
-comm -23 /tmp/registry.txt /tmp/files.txt | grep . && (echo "ERROR: registry entry without matching .md"; exit 1) || echo "No orphan registry entries ✓"
+ls patterns/*.md | xargs -n1 basename | sed 's/.md$//' | grep -v README | sort > "$PATTERN_FILES"
+echo "=== Registry ==="; cat "$REGISTRY_FILE"
+echo "=== Files ==="; cat "$PATTERN_FILES"
+comm -23 "$PATTERN_FILES" "$REGISTRY_FILE" | grep . && (echo "ERROR: pattern md file(s) missing from registry.yaml"; exit 1) || echo "All pattern files registered ✓"
+comm -23 "$REGISTRY_FILE" "$PATTERN_FILES" | grep . && (echo "ERROR: registry entry without matching .md"; exit 1) || echo "No orphan registry entries ✓"
 
 echo "Checking that key sections exist in patterns (lightweight)"
 for f in patterns/*.md; do


### PR DESCRIPTION
## Summary

Make the shared audit and validation gate scripts safe to run concurrently from separate worktrees by isolating each invocation's temporary files.

## Problem

Running `scripts/ci-audit-gates.sh` concurrently from two worktrees reproduced a race on the shared `/tmp/root-audit.json` and starter JSON files. One invocation failed while parsing a partially overwritten file:

```text
SyntaxError: Unexpected end of JSON input
```

A serial rerun passed, which isolated the failure to the fixed cross-process temp paths rather than the audit content.

No matching open Issue or PR was found; this was discovered while dogfooding the repository's own gates.

## Changes

- [ ] New pattern or starter
- [ ] Doc / example improvement
- [x] Tool change (shared CI gate scripts)
- [ ] Story

- Create a unique `mktemp` directory per audit or validation invocation and remove it on exit.
- Keep all intermediate JSON and registry comparison files inside that directory.
- Preserve the audit workflow's PR-comment handoff through an explicit `LOOP_AUDIT_OUTPUT_FILE` path under `${{ runner.temp }}`.
- Pass filenames and starter names to Node through environment variables instead of embedding them in JavaScript source.

## Checklist (from CONTRIBUTING)

- [x] Pattern sections reviewed (not applicable; no pattern content changed)
- [x] Link/index requirements reviewed (not applicable; no documentation changed)
- [x] No secrets, tokens, or internal company URLs
- [x] `STATE.md*` convention reviewed (not applicable)
- [x] Safety guidance reviewed (not applicable; behavior is unchanged)
- [x] Ran the repository audit and validation gates

## Testing / Dogfood

- [x] Reproduced the baseline failure with two worktrees running `bash scripts/ci-audit-gates.sh` concurrently
- [x] Ran two post-fix audit invocations concurrently; both passed and produced independently parseable JSON outputs
- [x] Ran two post-fix `bash scripts/ci-validate-gates.sh` invocations concurrently; both completed successfully
- [x] Ran `bash scripts/ci-audit-gates.sh` serially with `LOOP_AUDIT_OUTPUT_FILE` and parsed the exported JSON
- [x] Ran `bash scripts/ci-validate-gates.sh` serially
- [x] Ran `bash -n scripts/ci-audit-gates.sh scripts/ci-validate-gates.sh`
- [x] Parsed `.github/workflows/audit.yml` with the repository's YAML dependency
- [x] Ran `git diff --check`

The validation gate's `mcp-server` install still reports the repository's existing two moderate dependency advisories; this change adds no dependencies and both validation runs exit successfully.

## Screenshots / Examples

Not applicable; this change has no UI.
