### PR TITLE
chore: refresh RELEASE_NOTES_DRAFT for release prep (#332)

### DIFF
--- a/RELEASE_NOTES_DRAFT.md
+++ b/RELEASE_NOTES_DRAFT.md
@@ -1,10 +1,10 @@
-# Release notes draft — since Discussion #294
+# Release notes draft — week of 2026-07-20 (updated 2026-07-23)
 
 **Status:** Draft for human review ([#332](https://github.com/cobusgreyling/loop-engineering/issues/332)). Edit before publishing a discussion post or tagging packages.
 
-**Last published:** [Discussion #294](https://github.com/cobusgreyling/loop-engineering/discussions/294) (2026-07-16) — `loop-context` 1.2.0, `loop-worktree` 1.1.0.
+**Last published discussion:** [Discussion #294](https://github.com/cobusgreyling/loop-engineering/discussions/294) (2026-07-16) — `loop-context` 1.2.0, `loop-worktree` 1.1.0.
 
-**Window:** 2026-07-16 → 2026-07-22
+**Window:** 2026-07-16 → 2026-07-23
 
 ---
 
@@ -12,8 +12,8 @@
 
 ### Prompt caching cost model ([#346](https://github.com/cobusgreyling/loop-engineering/pull/346), [#347](https://github.com/cobusgreyling/loop-engineering/pull/347))
 
-- **`loop-cost` 1.2.0** — `--with-caching` scenario + `stable_fraction` on patterns in `registry.yaml` (cache-read discount on stable report/action tokens).
-- **`loop-context` 1.5.0** — `--budget-scenario caching` resolves a cap from the new scenario (shells out with `--with-caching`).
+- **`loop-cost` 1.2.0** (published) — `--with-caching` scenario + `stable_fraction` on patterns in `registry.yaml`.
+- **`loop-context` 1.5.0** (published) — `--budget-scenario caching` resolves a cap from the new scenario.
 
 ```bash
 npx @cobusgreyling/loop-cost --pattern daily-triage --level L1 --with-caching
@@ -23,36 +23,62 @@ npx @cobusgreyling/loop-context --check --ledger run.json \
 
 Thanks [@Tusm11](https://github.com/Tusm11).
 
-### Circuit breaker + packages already on npm
+### Memory bridge + loop-audit auto-fix (merged, **needs version bumps**)
 
-| Package | Version | Notes |
-|---------|---------|--------|
-| `@cobusgreyling/loop-context` | **1.4.0** (live) → **1.5.0** (this batch) | Frustration circuit breaker [#337](https://github.com/cobusgreyling/loop-engineering/pull/337); caching scenario this batch |
-| `@cobusgreyling/loop-cost` | **1.1.0** (live) → **1.2.0** (this batch) | Prompt-caching estimate this batch |
-| `@cobusgreyling/loop-audit` | **1.7.0** | Live |
-| `@cobusgreyling/loop-init` | **1.5.0** | Live |
-| `@cobusgreyling/loop-worktree` | **1.2.0** | Wait queue + deadlock detection [#292](https://github.com/cobusgreyling/loop-engineering/pull/292); published |
-| `@cobusgreyling/loop-gate` | **1.0.0** | First publish from [#291](https://github.com/cobusgreyling/loop-engineering/pull/291); live |
-| `@cobusgreyling/goal-init` | **1.0.0** | First publish |
-| `@cobusgreyling/readiness-core` | **1.0.0** | First publish (build before loop-audit in CI) |
+Landed on `main` 2026-07-23 but **package versions were not bumped** — still report as 1.7.0 / 1.5.0 / 1.1.0 on npm until publish PR + tags.
 
-### Docs appendices (primitives matrix)
+| Change | PR | Suggested next version |
+|--------|-----|------------------------|
+| `loop-audit --auto-fix` self-heal | [#358](https://github.com/cobusgreyling/loop-engineering/pull/358) | `loop-audit` **1.8.0** |
+| Memory-engineering bridge (`--with-memory`, Memory Ready signals) | [#359](https://github.com/cobusgreyling/loop-engineering/pull/359) | `loop-init` **1.6.0** + `loop-audit` **1.8.0** |
+| MCP: `loop_audit_score` + `loop_check_breaker` tools | [#360](https://github.com/cobusgreyling/loop-engineering/pull/360) | `loop-mcp-server` **1.2.0** |
 
-| PR | Contributor | Tool |
-|----|-------------|------|
-| [#351](https://github.com/cobusgreyling/loop-engineering/pull/351) | @shixi-li | Continue.dev (closes #117) |
-| [#350](https://github.com/cobusgreyling/loop-engineering/pull/350) | @adity982 | GitHub Copilot (closes #196) |
+Thanks [@THRISHAL12345](https://github.com/THRISHAL12345).
 
-### Other notable merges (window)
+### CI reliability
 
-- `loop-worktree` npm path + macOS gc fix [#204](https://github.com/cobusgreyling/loop-engineering/pull/204)
-- Star-history docs + chart automation [#193](https://github.com/cobusgreyling/loop-engineering/pull/193), [#205](https://github.com/cobusgreyling/loop-engineering/pull/205), [#192](https://github.com/cobusgreyling/loop-engineering/pull/192)
-- Daily triage CI: build readiness-core before loop-audit [#349](https://github.com/cobusgreyling/loop-engineering/pull/349)
-- Community docs/stories: multi-loop coordination, Opencode constraints, Hermes examples
+- Isolate audit/validation gate temp files for concurrent worktrees [#362](https://github.com/cobusgreyling/loop-engineering/pull/362) (thanks [@shixi-li](https://github.com/shixi-li))
+- Build `readiness-core` before loop-audit in daily-triage [#349](https://github.com/cobusgreyling/loop-engineering/pull/349)
+
+### Docs — primitives matrix + Cursor examples
+
+| PR | Contributor | Topic |
+|----|-------------|--------|
+| [#355](https://github.com/cobusgreyling/loop-engineering/pull/355) | @shixi-li | Cline appendix (GFI #147) |
+| [#356](https://github.com/cobusgreyling/loop-engineering/pull/356) | @shixi-li | Cursor CI Sweeper example (GFI #220) |
+| [#357](https://github.com/cobusgreyling/loop-engineering/pull/357) | @shixi-li | Cursor Changelog Drafter example (GFI #223) |
+| [#351](https://github.com/cobusgreyling/loop-engineering/pull/351) | @shixi-li | Continue.dev appendix (GFI #117) |
+| [#350](https://github.com/cobusgreyling/loop-engineering/pull/350) | @adity982 | GitHub Copilot appendix (GFI #196) |
 
 ---
 
-## Try it
+## Package status (as of 2026-07-23)
+
+| Package | On npm | On main (unreleased work?) | Action |
+|---------|--------|----------------------------|--------|
+| `@cobusgreyling/loop-cost` | **1.2.0** | 1.2.0 | Done |
+| `@cobusgreyling/loop-context` | **1.5.0** | 1.5.0 | Done |
+| `@cobusgreyling/loop-audit` | **1.7.0** | features from #358/#359 without version bump | Bump → **1.8.0**, changelog, tag |
+| `@cobusgreyling/loop-init` | **1.5.0** | `--with-memory` from #359 without version bump | Bump → **1.6.0**, tag |
+| `@cobusgreyling/loop-mcp-server` | **1.1.0** | MCP tools from #360 without version bump | Bump → **1.2.0**, tag |
+| `@cobusgreyling/loop-worktree` | **1.2.0** | — | No change |
+| `@cobusgreyling/loop-gate` | **1.0.0** | — | No change |
+| `@cobusgreyling/goal-init` | **1.0.0** | — | No change |
+| `@cobusgreyling/readiness-core` | **1.0.0** | — | No change |
+| `@cobusgreyling/loop-sync` | **1.0.0** | — | Verify if needed |
+
+### Suggested publish sequence (after version PR)
+
+1. Human: open version-bump PR for `loop-audit` 1.8.0, `loop-init` 1.6.0, `loop-mcp-server` 1.2.0 (+ CHANGELOG rows).
+2. Merge version PR.
+3. Tag in order (audit before consumers if needed):  
+   `loop-audit-v1.8.0` → `loop-init-v1.6.0` → `loop-mcp-server-v1.2.0`
+4. Confirm with `npm view @cobusgreyling/<pkg> version`.
+5. Human: fold this draft into a GitHub Discussion / announce; then close [#332](https://github.com/cobusgreyling/loop-engineering/issues/332).
+
+---
+
+## Try it (published today)
 
 ```bash
 npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok
@@ -61,36 +87,17 @@ npx @cobusgreyling/loop-cost --pattern daily-triage --level L1 --with-caching
 npx @cobusgreyling/loop-worktree list
 ```
 
----
+After the 1.8 / 1.6 / 1.2.0 publishes:
 
-## npm publish checklist (2026-07-22)
-
-| Package | On npm now | This PR / tag | Action |
-|---------|------------|---------------|--------|
-| `@cobusgreyling/loop-cost` | **1.2.0** | `loop-cost-v1.2.0` | **Published** |
-| `@cobusgreyling/loop-context` | **1.5.0** | `loop-context-v1.5.0` | **Published** |
-| `@cobusgreyling/loop-audit` | 1.7.0 | — | No change |
-| `@cobusgreyling/loop-init` | 1.5.0 | — | No change |
-| `@cobusgreyling/loop-worktree` | 1.2.0 | — | Already published |
-| `@cobusgreyling/loop-gate` | 1.0.0 | — | Already published |
-| `@cobusgreyling/goal-init` | 1.0.0 | — | Already published |
-| `@cobusgreyling/readiness-core` | 1.0.0 | — | Already published |
-| `@cobusgreyling/loop-mcp-server` | 1.1.0* | — | No change (*confirm if needed) |
-| `@cobusgreyling/loop-sync` | 1.0.0* | — | No change |
-
-\* Verify with `npm view @cobusgreyling/<pkg> version` before any announce.
-
-### Suggested publish steps
-
-1. ~~Merge version bump PR #352~~ done.
-2. ~~Tag `loop-cost-v1.2.0` + `loop-context-v1.5.0`~~ done; release workflows green.
-3. ~~`npm view` → 1.2.0 / 1.5.0~~ confirmed.
-4. Human: fold this draft into discussion/announce for [#332](https://github.com/cobusgreyling/loop-engineering/issues/332) when ready.
-5. Superseded contributor draft [#348](https://github.com/cobusgreyling/loop-engineering/pull/348) (closed).
+```bash
+npx @cobusgreyling/loop-audit . --auto-fix   # when 1.8.0 is live
+npx @cobusgreyling/loop-init . --pattern daily-triage --with-memory
+```
 
 ---
 
-## Housekeeping
+## Housekeeping (this prep window)
 
-- PR triage 2026-07-22: merged #351/#350; closed #344 superseded; held then superseded #348.
-- Feature PRs must include `package.json` bumps + this checklist row in the same change (lesson from #346/#347 gap).
+- Docs batch + tooling merged 2026-07-23: #355–#363 (see PR list above).
+- Zero open PRs after housekeeping; remaining GFIs include #224 (Cursor Issue Triage — draft PR), #195, stories.
+- Feature PRs that land on `tools/*` should include `package.json` version bumps in the **same** change (lesson from #346/#347 and repeated for #358–#360).

--- a/changelog-drafter-state.md
+++ b/changelog-drafter-state.md
@@ -1,0 +1,27 @@
+# Changelog Drafter State
+
+Last run: 2026-07-23T12:15:00Z (manual release prep for #332)
+Last published discussion: #294 (2026-07-16)
+Scan window: 2026-07-16 → 2026-07-23 (main)
+
+## Pending draft
+
+- File: `RELEASE_NOTES_DRAFT.md`
+- Sources: merged PRs #346–#363 (selected); bot star-history / daily-triage noise excluded
+- Breaking changes: 0 known
+- Security items: 0
+- Status: **pending human review**
+
+## Publish gate
+
+- Source verification: pending human
+- Attribution review: pending human
+- Version bumps for #358/#359/#360: **required before npm announce**
+- Tag / GitHub Release / Discussions: denied to automation — human only
+
+## Next actions (human)
+
+1. Review `RELEASE_NOTES_DRAFT.md`
+2. Open version-bump PR (loop-audit 1.8.0, loop-init 1.6.0, loop-mcp-server 1.2.0)
+3. Tag + publish
+4. Post discussion / close #332


### PR DESCRIPTION
## Summary

Updates release prep for **#332** (changelog-drafter L1 dogfood).

- Refreshes `RELEASE_NOTES_DRAFT.md` for window 2026-07-16 → 2026-07-23
- Records published work (`loop-cost` 1.2.0, `loop-context` 1.5.0)
- Surfaces **unpublished** main-branch features that need version bumps:
  - `loop-audit` → 1.8.0 (#358/#359)
  - `loop-init` → 1.6.0 (#359)
  - `loop-mcp-server` → 1.2.0 (#360)
- Adds `changelog-drafter-state.md` with scan window + human publish gate

## Not in this PR

- No npm tags or publishes (human gate)
- No package.json version bumps (separate version PR recommended)

## Human next steps

1. Review the draft wording
2. Open version-bump PR for the three packages above
3. Tag + publish, then Discussion + close #332

Related: #332

## Checklist

- [x] Draft PR only
- [x] Report-only — no tags, no Discussions post, no auto-publish