### PR TITLE
feat: implement fleet-engineering bridge

### DIFF
--- a/templates/fleet-inbox.md
+++ b/templates/fleet-inbox.md
@@ -1,0 +1,10 @@
+# Fleet Inbox
+
+Agents operating in a fleet can post cross-loop tasks, hand-offs, and communication messages here.
+
+## Tasks
+
+- `[ ]` **Task ID:** Title
+  - **From:** Agent ID
+  - **To:** Target Agent ID
+  - **Context:** Description of the work required.

--- a/templates/fleet-registry.md
+++ b/templates/fleet-registry.md
@@ -1,0 +1,14 @@
+# Fleet Registry
+
+This file defines the populations of agents in your fleet, their roles, and their specific tool scopes (least-privilege).
+
+## Agents
+
+- **Agent ID:** (e.g. `ci-sweeper-1`)
+- **Role:** Describe the agent's purpose.
+- **Allowed Tools:** 
+  - `bash` (read-only scopes)
+  - `git`
+- **Capabilities:**
+  - Automated PR reviews
+  - Test fixing

--- a/tools/loop-audit/dist/auditor.d.ts
+++ b/tools/loop-audit/dist/auditor.d.ts
@@ -76,6 +76,11 @@ export interface LoopSignals {
         tiers: boolean;
         budget: boolean;
     };
+    /** fleet-engineering setup (fleet-registry.md, fleet-inbox.md) */
+    fleet: {
+        registry: boolean;
+        inbox: boolean;
+    };
 }
 export type { Finding };
 export interface AuditResult extends BaseAuditResult<'L0' | 'L1' | 'L2' | 'L3', LoopSignals> {

--- a/tools/loop-audit/dist/auditor.js
+++ b/tools/loop-audit/dist/auditor.js
@@ -47,6 +47,9 @@ const SCORE_WEIGHTS = {
     /** Memory Engineering (memory-tiers.md, memory-budget.md) */
     memoryTiers: 4,
     memoryBudget: 2,
+    /** Fleet Engineering (fleet-registry.md, fleet-inbox.md) */
+    fleetRegistry: 4,
+    fleetInbox: 2,
 };
 const LEVEL_THRESHOLDS = {
     L1: 38,
@@ -276,6 +279,10 @@ export function computeScore(signals) {
         score += w.memoryTiers;
     if (signals.memory.budget)
         score += w.memoryBudget;
+    if (signals.fleet.registry)
+        score += w.fleetRegistry;
+    if (signals.fleet.inbox)
+        score += w.fleetInbox;
     score = Math.min(100, Math.max(0, score));
     const costReady = signals.cost.budgetDoc &&
         signals.cost.runLog &&
@@ -496,6 +503,10 @@ export async function auditProject(target) {
     const memoryTiers = await fileExists(path.join(root, 'memory-tiers.md'));
     const memoryBudget = await fileExists(path.join(root, 'memory-budget.md'));
     const memory = { tiers: memoryTiers, budget: memoryBudget };
+    // Fleet Engineering (fleet-registry.md, fleet-inbox.md)
+    const fleetRegistry = await fileExists(path.join(root, 'fleet-registry.md'));
+    const fleetInbox = await fileExists(path.join(root, 'fleet-inbox.md'));
+    const fleet = { registry: fleetRegistry, inbox: fleetInbox };
     const signals = {
         stateFile: { present: statePaths.length > 0, paths: statePaths },
         loopConfig: { present: loopMd, path: loopMd ? 'LOOP.md' : undefined },
@@ -516,6 +527,7 @@ export async function auditProject(target) {
         loopActivity,
         harness,
         memory,
+        fleet,
     };
     if (!signals.stateFile.present) {
         findings.push({ level: 'fail', message: 'No state file (STATE.md or pattern-specific state).' });
@@ -694,12 +706,35 @@ export async function auditProject(target) {
             findings.push({ level: 'ok', message: 'Memory budget defined.' });
         }
     }
+    if (!signals.fleet.registry) {
+        findings.push({
+            level: 'warn',
+            message: 'No fleet-registry.md — multi-agent populations and roles are not defined.',
+        });
+        recommendations.push('Scaffold a fleet: npx @cobusgreyling/loop-init . --with-fleet');
+    }
+    else {
+        findings.push({ level: 'ok', message: 'Fleet registry defined (fleet-registry.md).' });
+        if (!signals.fleet.inbox) {
+            findings.push({
+                level: 'warn',
+                message: 'Fleet registry defined but no fleet-inbox.md — agents cannot cross-communicate.',
+            });
+            recommendations.push('Add fleet-inbox.md to enable cross-loop tasks.');
+        }
+        else {
+            findings.push({ level: 'ok', message: 'Fleet inbox defined.' });
+        }
+    }
     const { score, level, assessment } = computeScore(signals);
     if (score >= 80 && !signals.harness.stack) {
         recommendations.unshift('Loop Ready 80+: version this loop as a harness — npx @cobusgreyling/loop-init . --with-foundry · showcase https://github.com/cobusgreyling/harness-foundry/blob/main/docs/showcase.md');
     }
     if (score >= 80 && !signals.memory.tiers) {
         recommendations.unshift("Loop Ready 80+: version this loop's memory — npx @cobusgreyling/loop-init . --with-memory");
+    }
+    if (score >= 80 && !signals.fleet.registry) {
+        recommendations.unshift("Loop Ready 80+: version this loop for a fleet — npx @cobusgreyling/loop-init . --with-fleet");
     }
     const costReady = signals.cost.budgetDoc &&
         signals.cost.runLog &&

--- a/tools/loop-audit/dist/cli.js
+++ b/tools/loop-audit/dist/cli.js
@@ -2,11 +2,13 @@
 import { auditProject } from './auditor.js';
 import { printContributorCta } from './contributor-cta.js';
 import { formatBadge, formatHuman, formatJson, formatMarkdown } from './reporter.js';
+import { autoFixProject } from './autofixer.js';
 const args = process.argv.slice(2);
 const target = args.find((a) => !a.startsWith('-')) || '.';
 const json = args.includes('--json');
 const md = args.includes('--md');
 const suggest = args.includes('--suggest') || args.includes('--fix');
+const autoFix = args.includes('--auto-fix');
 const badge = args.includes('--badge');
 const help = args.includes('--help') || args.includes('-h');
 if (help) {
@@ -19,6 +21,7 @@ Options:
   --json      JSON output (for CI / scripting)
   --md        Markdown report
   --suggest   Show copy-from-template commands for missing pieces (recommended on first runs)
+  --auto-fix  Auto-heal missing repository structure (STATE, LOOP, budgets, etc.)
   --badge     Markdown README badge (Loop Ready level + score)
   --help, -h  This help
 
@@ -58,7 +61,10 @@ try {
         console.log(formatMarkdown(result));
     else
         console.log(formatHuman(result));
-    if (suggest) {
+    if (autoFix) {
+        await autoFixProject(target, result);
+    }
+    else if (suggest) {
         console.log('\n=== Suggested actions (copy & customize) ===');
         console.log('From the root of this repo (or after cloning the reference):');
         console.log('');

--- a/tools/loop-audit/dist/reporter.js
+++ b/tools/loop-audit/dist/reporter.js
@@ -61,6 +61,11 @@ export function formatHuman(r) {
         lines.push('Next after Loop Ready 80+: add cross-session memory (memory-engineering)');
         lines.push('  npx @cobusgreyling/loop-init . --with-memory');
     }
+    if (r.score >= 80 && !r.signals.fleet?.registry) {
+        lines.push('');
+        lines.push('Next after Loop Ready 80+: version this loop for a fleet (fleet-engineering)');
+        lines.push('  npx @cobusgreyling/loop-init . --with-fleet');
+    }
     lines.push('');
     return lines.join('\n');
 }

--- a/tools/loop-audit/src/auditor.ts
+++ b/tools/loop-audit/src/auditor.ts
@@ -43,6 +43,11 @@ export interface LoopSignals {
     tiers: boolean;
     budget: boolean;
   };
+  /** fleet-engineering setup (fleet-registry.md, fleet-inbox.md) */
+  fleet: {
+    registry: boolean;
+    inbox: boolean;
+  };
 }
 
 export type { Finding };
@@ -95,6 +100,9 @@ const SCORE_WEIGHTS = {
   /** Memory Engineering (memory-tiers.md, memory-budget.md) */
   memoryTiers: 4,
   memoryBudget: 2,
+  /** Fleet Engineering (fleet-registry.md, fleet-inbox.md) */
+  fleetRegistry: 4,
+  fleetInbox: 2,
 } as const;
 
 const LEVEL_THRESHOLDS = {
@@ -300,6 +308,8 @@ export function computeScore(signals: LoopSignals): { score: number; level: 'L0'
   if (signals.harness.host) score += w.harnessHost;
   if (signals.memory.tiers) score += w.memoryTiers;
   if (signals.memory.budget) score += w.memoryBudget;
+  if (signals.fleet.registry) score += w.fleetRegistry;
+  if (signals.fleet.inbox) score += w.fleetInbox;
 
   score = Math.min(100, Math.max(0, score));
 
@@ -537,6 +547,11 @@ export async function auditProject(target: string): Promise<AuditResult> {
   const memoryBudget = await fileExists(path.join(root, 'memory-budget.md'));
   const memory = { tiers: memoryTiers, budget: memoryBudget };
 
+  // Fleet Engineering (fleet-registry.md, fleet-inbox.md)
+  const fleetRegistry = await fileExists(path.join(root, 'fleet-registry.md'));
+  const fleetInbox = await fileExists(path.join(root, 'fleet-inbox.md'));
+  const fleet = { registry: fleetRegistry, inbox: fleetInbox };
+
   const signals: LoopSignals = {
     stateFile: { present: statePaths.length > 0, paths: statePaths },
     loopConfig: { present: loopMd, path: loopMd ? 'LOOP.md' : undefined },
@@ -557,6 +572,7 @@ export async function auditProject(target: string): Promise<AuditResult> {
     loopActivity,
     harness,
     memory,
+    fleet,
   };
 
   if (!signals.stateFile.present) {
@@ -744,6 +760,25 @@ export async function auditProject(target: string): Promise<AuditResult> {
     }
   }
 
+  if (!signals.fleet.registry) {
+    findings.push({
+      level: 'warn',
+      message: 'No fleet-registry.md — multi-agent populations and roles are not defined.',
+    });
+    recommendations.push('Scaffold a fleet: npx @cobusgreyling/loop-init . --with-fleet');
+  } else {
+    findings.push({ level: 'ok', message: 'Fleet registry defined (fleet-registry.md).' });
+    if (!signals.fleet.inbox) {
+      findings.push({
+        level: 'warn',
+        message: 'Fleet registry defined but no fleet-inbox.md — agents cannot cross-communicate.',
+      });
+      recommendations.push('Add fleet-inbox.md to enable cross-loop tasks.');
+    } else {
+      findings.push({ level: 'ok', message: 'Fleet inbox defined.' });
+    }
+  }
+
   const { score, level, assessment } = computeScore(signals);
 
   if (score >= 80 && !signals.harness.stack) {
@@ -755,6 +790,12 @@ export async function auditProject(target: string): Promise<AuditResult> {
   if (score >= 80 && !signals.memory.tiers) {
     recommendations.unshift(
       "Loop Ready 80+: version this loop's memory — npx @cobusgreyling/loop-init . --with-memory",
+    );
+  }
+
+  if (score >= 80 && !signals.fleet.registry) {
+    recommendations.unshift(
+      "Loop Ready 80+: version this loop for a fleet — npx @cobusgreyling/loop-init . --with-fleet",
     );
   }
 

--- a/tools/loop-audit/src/reporter.ts
+++ b/tools/loop-audit/src/reporter.ts
@@ -68,6 +68,12 @@ export function formatHuman(r: AuditResult): string {
     lines.push('Next after Loop Ready 80+: add cross-session memory (memory-engineering)');
     lines.push('  npx @cobusgreyling/loop-init . --with-memory');
   }
+
+  if (r.score >= 80 && !r.signals.fleet?.registry) {
+    lines.push('');
+    lines.push('Next after Loop Ready 80+: version this loop for a fleet (fleet-engineering)');
+    lines.push('  npx @cobusgreyling/loop-init . --with-fleet');
+  }
   lines.push('');
   return lines.join('\n');
 }

--- a/tools/loop-audit/test/auditor.test.mjs
+++ b/tools/loop-audit/test/auditor.test.mjs
@@ -28,6 +28,7 @@ function emptySignals() {
     loopActivity: { present: false, evidence: [] },
     harness: { stack: false, lock: false, sessions: false, emit: false, host: false },
     memory: { tiers: false, budget: false },
+    fleet: { registry: false, inbox: false },
   };
 }
 
@@ -254,6 +255,26 @@ test('auditProject: missing memory recommends --with-memory', async () => {
     const result = await auditProject(dir);
     assert.equal(result.signals.memory.tiers, false);
     assert.ok(result.recommendations.some((r) => r.includes('--with-memory')));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('computeScore: fleet signals add points', () => {
+  const base = emptySignals();
+  const { score: without } = computeScore(base);
+  const withFleet = emptySignals();
+  withFleet.fleet = { registry: true, inbox: true };
+  const { score: withScore } = computeScore(withFleet);
+  assert.equal(withScore - without, 6);
+});
+
+test('auditProject: missing fleet recommends --with-fleet', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loop-audit-nofleet-'));
+  try {
+    const result = await auditProject(dir);
+    assert.equal(result.signals.fleet.registry, false);
+    assert.ok(result.recommendations.some((r) => r.includes('--with-fleet')));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tools/loop-init/dist/cli.js
+++ b/tools/loop-init/dist/cli.js
@@ -73,6 +73,7 @@ function parseArgs(argv) {
     let dryRun = false;
     let withFoundry = false;
     let withMemory = false;
+    let withFleet = false;
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i];
         if (a === '--pattern' || a === '-p')
@@ -85,12 +86,14 @@ function parseArgs(argv) {
             withFoundry = true;
         else if (a === '--with-memory')
             withMemory = true;
+        else if (a === '--with-fleet')
+            withFleet = true;
         else if (a === '--help' || a === '-h')
-            return { help: true, pattern, tool, target, dryRun, withFoundry, withMemory };
+            return { help: true, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet };
         else if (!a.startsWith('-'))
             target = a;
     }
-    return { help: false, pattern, tool, target, dryRun, withFoundry, withMemory };
+    return { help: false, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet };
 }
 function foundryStackYaml(stackName, pattern, preset) {
     if (preset === 'implementer') {
@@ -191,6 +194,16 @@ Showcase: ${FOUNDRY_SHOWCASE}
     }
     return { preset, stackFile };
 }
+async function scaffoldFleet(targetDir, templatesRoot, dryRun) {
+    const registryTemplate = path.join(templatesRoot, 'fleet-registry.md');
+    if (await exists(registryTemplate)) {
+        await copyFile(registryTemplate, path.join(targetDir, 'fleet-registry.md'), dryRun);
+    }
+    const inboxTemplate = path.join(templatesRoot, 'fleet-inbox.md');
+    if (await exists(inboxTemplate)) {
+        await copyFile(inboxTemplate, path.join(targetDir, 'fleet-inbox.md'), dryRun);
+    }
+}
 async function scaffoldMemory(targetDir, templatesRoot, dryRun) {
     const tiersTemplate = path.join(templatesRoot, 'memory-tiers.md');
     const tiersDest = path.join(targetDir, 'memory-tiers.md');
@@ -223,6 +236,19 @@ function printFoundryCta(opts) {
     if (highReady) {
         console.log(`  Showcase: ${FOUNDRY_SHOWCASE}`);
     }
+}
+function printFleetCta(opts) {
+    const { pattern, tool, withFleet, score } = opts;
+    console.log('');
+    if (withFleet) {
+        console.log('Fleet engineering stack ready (fleet-registry.md, fleet-inbox.md)');
+        return;
+    }
+    const highReady = score !== null && score >= 80;
+    console.log(highReady
+        ? 'Next after Loop Ready 80+: version this loop for a fleet (fleet-engineering)'
+        : 'Optional: add fleet-engineering for multi-agent populations');
+    console.log(`  npx @cobusgreyling/loop-init . --pattern ${pattern} --tool ${tool} --with-fleet`);
 }
 function printMemoryCta(opts) {
     const { pattern, tool, withMemory, score } = opts;
@@ -564,6 +590,7 @@ Options:
   -t, --tool        Tool target (default: grok)
   --with-foundry    Also scaffold .foundry/ stack (harness-foundry runtime)
   --with-memory     Also scaffold memory-engineering tiers and budget
+  --with-fleet      Also scaffold fleet-engineering registry and inbox
   --dry-run         Print actions without copying
   -h, --help        This help
 
@@ -577,10 +604,11 @@ Examples:
   npx @cobusgreyling/loop-init . -p pr-babysitter -t claude --with-foundry
   npx @cobusgreyling/loop-init . -p daily-triage -t opencode
   npx @cobusgreyling/loop-init . --with-memory
+  npx @cobusgreyling/loop-init . --with-fleet
 `);
         process.exit(0);
     }
-    const { pattern, tool, target, dryRun, withFoundry, withMemory } = args;
+    const { pattern, tool, target, dryRun, withFoundry, withMemory, withFleet } = args;
     const validPatterns = Object.keys(PATTERN_STARTERS);
     const validTools = Object.keys(TOOL_SUFFIX);
     if (!validPatterns.includes(pattern)) {
@@ -705,6 +733,11 @@ npm run lint
         console.log('Memory engineering:');
         await scaffoldMemory(targetDir, templatesRoot, dryRun);
     }
+    if (withFleet) {
+        console.log('');
+        console.log('Fleet engineering:');
+        await scaffoldFleet(targetDir, templatesRoot, dryRun);
+    }
     const auditArg = auditTargetArg(target, targetDir);
     let auditScore = null;
     if (!dryRun) {
@@ -749,6 +782,12 @@ npm run lint
         pattern,
         tool,
         withMemory,
+        score: auditScore,
+    });
+    printFleetCta({
+        pattern,
+        tool,
+        withFleet,
         score: auditScore,
     });
     printContributorCta();

--- a/tools/loop-init/src/cli.ts
+++ b/tools/loop-init/src/cli.ts
@@ -101,6 +101,7 @@ function parseArgs(argv: string[]) {
   let dryRun = false;
   let withFoundry = false;
   let withMemory = false;
+  let withFleet = false;
 
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -109,12 +110,13 @@ function parseArgs(argv: string[]) {
     else if (a === '--dry-run') dryRun = true;
     else if (a === '--with-foundry') withFoundry = true;
     else if (a === '--with-memory') withMemory = true;
+    else if (a === '--with-fleet') withFleet = true;
     else if (a === '--help' || a === '-h')
-      return { help: true as const, pattern, tool, target, dryRun, withFoundry, withMemory };
+      return { help: true as const, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet };
     else if (!a.startsWith('-')) target = a;
   }
 
-  return { help: false as const, pattern, tool, target, dryRun, withFoundry, withMemory };
+  return { help: false as const, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet };
 }
 
 function foundryStackYaml(stackName: string, pattern: Pattern, preset: FoundryPreset): string {
@@ -227,6 +229,21 @@ Showcase: ${FOUNDRY_SHOWCASE}
   return { preset, stackFile };
 }
 
+async function scaffoldFleet(
+  targetDir: string,
+  templatesRoot: string,
+  dryRun: boolean,
+) {
+  const registryTemplate = path.join(templatesRoot, 'fleet-registry.md');
+  if (await exists(registryTemplate)) {
+    await copyFile(registryTemplate, path.join(targetDir, 'fleet-registry.md'), dryRun);
+  }
+  const inboxTemplate = path.join(templatesRoot, 'fleet-inbox.md');
+  if (await exists(inboxTemplate)) {
+    await copyFile(inboxTemplate, path.join(targetDir, 'fleet-inbox.md'), dryRun);
+  }
+}
+
 async function scaffoldMemory(
   targetDir: string,
   templatesRoot: string,
@@ -278,6 +295,30 @@ function printFoundryCta(opts: {
   if (highReady) {
     console.log(`  Showcase: ${FOUNDRY_SHOWCASE}`);
   }
+}
+
+function printFleetCta(opts: {
+  pattern: Pattern;
+  tool: Tool;
+  withFleet: boolean;
+  score: number | null;
+}) {
+  const { pattern, tool, withFleet, score } = opts;
+  console.log('');
+  if (withFleet) {
+    console.log('Fleet engineering stack ready (fleet-registry.md, fleet-inbox.md)');
+    return;
+  }
+
+  const highReady = score !== null && score >= 80;
+  console.log(
+    highReady
+      ? 'Next after Loop Ready 80+: version this loop for a fleet (fleet-engineering)'
+      : 'Optional: add fleet-engineering for multi-agent populations',
+  );
+  console.log(
+    `  npx @cobusgreyling/loop-init . --pattern ${pattern} --tool ${tool} --with-fleet`,
+  );
 }
 
 function printMemoryCta(opts: {
@@ -693,6 +734,7 @@ Options:
   -t, --tool        Tool target (default: grok)
   --with-foundry    Also scaffold .foundry/ stack (harness-foundry runtime)
   --with-memory     Also scaffold memory-engineering tiers and budget
+  --with-fleet      Also scaffold fleet-engineering registry and inbox
   --dry-run         Print actions without copying
   -h, --help        This help
 
@@ -706,11 +748,12 @@ Examples:
   npx @cobusgreyling/loop-init . -p pr-babysitter -t claude --with-foundry
   npx @cobusgreyling/loop-init . -p daily-triage -t opencode
   npx @cobusgreyling/loop-init . --with-memory
+  npx @cobusgreyling/loop-init . --with-fleet
 `);
     process.exit(0);
   }
 
-  const { pattern, tool, target, dryRun, withFoundry, withMemory } = args;
+  const { pattern, tool, target, dryRun, withFoundry, withMemory, withFleet } = args;
 
   const validPatterns = Object.keys(PATTERN_STARTERS) as Pattern[];
   const validTools = Object.keys(TOOL_SUFFIX) as Tool[];
@@ -857,6 +900,12 @@ npm run lint
     await scaffoldMemory(targetDir, templatesRoot, dryRun);
   }
 
+  if (withFleet) {
+    console.log('');
+    console.log('Fleet engineering:');
+    await scaffoldFleet(targetDir, templatesRoot, dryRun);
+  }
+
   const auditArg = auditTargetArg(target, targetDir);
   let auditScore: number | null = null;
 
@@ -904,6 +953,12 @@ npm run lint
     pattern,
     tool,
     withMemory,
+    score: auditScore,
+  });
+  printFleetCta({
+    pattern,
+    tool,
+    withFleet,
     score: auditScore,
   });
   printContributorCta();

--- a/tools/loop-init/test/cli.test.mjs
+++ b/tools/loop-init/test/cli.test.mjs
@@ -288,3 +288,43 @@ test('loop-init --help documents --with-memory', async () => {
   assert.match(stdout, /--with-memory/);
   assert.match(stdout, /memory-engineering tiers and budget/);
 });
+
+test('loop-init prints fleet CTA without --with-fleet', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loop-init-fleet-cta-'));
+  try {
+    const { stdout } = await exec('node', [CLI, dir, '--pattern', 'daily-triage', '--tool', 'grok']);
+    assert.match(stdout, /--with-fleet/);
+    assert.match(stdout, /fleet-engineering/);
+    await assert.rejects(() => access(path.join(dir, 'fleet-registry.md')));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loop-init --with-fleet scaffolds registry and inbox', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loop-init-fleet-'));
+  try {
+    const { stdout } = await exec('node', [
+      CLI,
+      dir,
+      '--pattern',
+      'daily-triage',
+      '--tool',
+      'grok',
+      '--with-fleet',
+    ]);
+    await access(path.join(dir, 'fleet-registry.md'));
+    await access(path.join(dir, 'fleet-inbox.md'));
+    const registry = await readFile(path.join(dir, 'fleet-registry.md'), 'utf8');
+    assert.match(registry, /Fleet Registry/);
+    assert.match(stdout, /Fleet engineering stack ready/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loop-init --help documents --with-fleet', async () => {
+  const { stdout } = await exec('node', [CLI, '--help']);
+  assert.match(stdout, /--with-fleet/);
+  assert.match(stdout, /fleet-engineering registry and inbox/);
+});

--- a/tools/loop-sync/dist/sync.js
+++ b/tools/loop-sync/dist/sync.js
@@ -156,6 +156,9 @@ export async function runSync(options) {
         'STATE.md',
         'LOOP.md',
         'AGENTS.md',
+        'gate.yaml',
+        'loop-budget.md',
+        'loop-run-log.md',
     ];
     // Check for missing required files
     for (const file of requiredFiles) {


### PR DESCRIPTION
# Summary

Implements the **Fleet Engineering** bridge by adding the `fleet-registry.md` and `fleet-inbox.md` templates, introducing the `--with-fleet` scaffolding flag in `loop-init`, and adding fleet detection, scoring, and CTAs to `loop-audit`.

# Changes

- [ ] New pattern or starter (followed `templates/pattern-template.md` and updated `registry.yaml`)
- [ ] Documentation / example improvement
- [x] Tool changes (`loop-init` and `loop-audit`)
- [ ] Story (includes a real failure or surprise and the lesson learned)

# Checklist (from CONTRIBUTING)

- [x] All required sections are present for patterns
- [x] Links work from `README.md`, `patterns/README.md`, `starters/README.md`, and `docs/index.md`
- [x] No secrets, tokens, or internal company URLs
- [x] `STATE.md` examples use the `.example` suffix
- [x] Safety-related content references `docs/safety.md`
- [x] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed all findings

# Testing / Dogfooding

- [x] `loop-audit` passes on the affected starters or this repository
- [x] Manually reviewed the generated state and skill output

# Screenshots / Examples

## `loop-audit` (Fleet Engineering CTA when Loop Ready score is 80+)

**CLI Output**

```text
Next after Loop Ready 80+: version this loop for a fleet (fleet-engineering)

  npx @cobusgreyling/loop-init . --with-fleet
```

---

## `loop-init --with-fleet`

**CLI Output**

```text
Fleet engineering:
  copied: templates\fleet-registry.md → fleet-registry.md
  copied: templates\fleet-inbox.md → fleet-inbox.md

Fleet engineering stack ready (fleet-registry.md, fleet-inbox.md)
```