### PR TITLE
docs: add Pluribus to the list of adopters in documentation

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -37,6 +37,7 @@ Or open a PR that adds a row to the table below:
 | [loop-engineering](https://github.com/cobusgreyling/loop-engineering) (maintainer) | Issue Triage + Daily Triage | Grok | L1 | Issue queue feeder: propose labels only week one; pairs with morning `STATE.md` triage |
 | [loop-engineering](https://github.com/cobusgreyling/loop-engineering) (maintainer) | PR Babysitter, Dependency Sweeper | Grok / Claude Code | L2 | Assisted fixes in worktrees; human gate on merges; patch-only deps |
 | [Hermes Agent](https://github.com/NousResearch/hermes-agent) by [Nous Research](https://nousresearch.com) | Daily Triage | Hermes | L1 | Six loop primitives in one binary — `hermes cron` + skill + `delegate_task` + MCP + memory. Reference: [examples/hermes/daily-triage.md](../examples/hermes/daily-triage.md) |
+| [Pluribus](https://github.com/caioribeiroclw-pixel/pluribus) | Daily Triage, Issue Triage | Mixed (OpenClaw) | L2 | Hourly market/adoption research loop; durable state in control plane; cross-tool privacy-safe receipts needed |
 
 *Your project here — see [CONTRIBUTING.md](../CONTRIBUTING.md).*
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -672,6 +672,11 @@ npx @cobusgreyling/loop-audit . --suggest
       <p class="adopter-meta">Issue Triage + Daily Triage · Grok · <strong>L1</strong></p>
       <p class="adopter-note">Propose labels only week one; pairs with morning STATE.md triage.</p>
     </article>
+    <article class="adopter-card card">
+      <h4><a href="https://github.com/caioribeiroclw-pixel/pluribus">Pluribus</a></h4>
+      <p class="adopter-meta">Daily Triage · Issue Triage · Mixed (OpenClaw) · <strong>L2</strong></p>
+      <p class="adopter-note">Hourly market/adoption research loop; durable state in control plane &amp; evidence boundaries.</p>
+    </article>
     <article class="adopter-card card adopter-placeholder">
       <h4>Your project here</h4>
       <p class="adopter-meta">Pattern · Tool · Level</p>


### PR DESCRIPTION
## Summary
<!-- One sentence what this does and why -->

## Changes
- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example improvement
- [ ] Tool change (loop-audit)
- [ ] Story (includes real failure or surprise + lesson)

## Checklist (from CONTRIBUTING)
- [ ] All required sections present for patterns
- [ ] Links work from README, patterns/README, starters/README, docs/index
- [ ] No secrets, tokens, internal company URLs
- [ ] `STATE.md*` examples use `.example` suffix
- [ ] Safety-related content references `docs/safety.md`
- [ ] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood
- [ ] `loop-audit` passes on affected starters or this repo
- [ ] Manual review of generated state / skill output

## Screenshots / Examples (if UI or command output)
<!-- Paste relevant output or link to rendered docs -->

---

*This template enforces the high bar this reference is known for.*
