### PR TITLE
test(loop-init): cover every scaffold combination

### DIFF
--- a/docs/loop-init-validation.md
+++ b/docs/loop-init-validation.md
@@ -22,6 +22,22 @@ git init
 npx @cobusgreyling/loop-init . --pattern daily-triage --tool claude
 \`\`\`
 
+## Automated contract
+
+The scaffold matrix in `tools/loop-init/test/cli.test.mjs` runs every supported
+pattern × tool combination in a fresh temporary directory. It verifies the
+state, observability, constraints, primary skill, and tool-specific files, plus
+the presence or absence of circuit-breaker and intake assets where required.
+
+\`\`\`
+cd tools/loop-init
+npm test
+\`\`\`
+
+The automated matrix guards the scaffold contract on every PR. The table below
+remains the place for manual UX checks such as the printed Loop Ready score,
+platform-specific behavior, and unexpected output.
+
 ## Matrix
 
 | Pattern | --tool | Loop Ready score | Files created | Notes |
@@ -34,5 +50,25 @@ npx @cobusgreyling/loop-init . --pattern daily-triage --tool claude
 | ci-sweeper | grok | | | |
 | ci-sweeper | codex | | | |
 | ci-sweeper | opencode | | | |
+| pr-babysitter | claude | | | |
+| pr-babysitter | grok | | | |
+| pr-babysitter | codex | | | |
+| pr-babysitter | opencode | | | |
+| dependency-sweeper | claude | | | |
+| dependency-sweeper | grok | | | |
+| dependency-sweeper | codex | | | |
+| dependency-sweeper | opencode | | | |
+| post-merge-cleanup | claude | | | |
+| post-merge-cleanup | grok | | | |
+| post-merge-cleanup | codex | | | |
+| post-merge-cleanup | opencode | | | |
+| changelog-drafter | claude | | | |
+| changelog-drafter | grok | | | |
+| changelog-drafter | codex | | | |
+| changelog-drafter | opencode | | | |
+| issue-triage | claude | | | |
+| issue-triage | grok | | | |
+| issue-triage | codex | | | |
+| issue-triage | opencode | | | |
 
 Empty rows are open for other contributors — see #231.

--- a/tools/loop-init/test/cli.test.mjs
+++ b/tools/loop-init/test/cli.test.mjs
@@ -350,3 +350,117 @@ test('loop-init --help documents --with-fleet', async () => {
   assert.match(stdout, /--with-fleet/);
   assert.match(stdout, /fleet-engineering registry and inbox/);
 });
+
+const SCAFFOLD_PATTERNS = {
+  'daily-triage': {
+    state: 'STATE.md',
+    primarySkill: 'loop-triage',
+    fixCapable: false,
+    intake: false,
+  },
+  'pr-babysitter': {
+    state: 'pr-babysitter-state.md',
+    primarySkill: 'pr-review-triage',
+    fixCapable: true,
+    intake: false,
+  },
+  'ci-sweeper': {
+    state: 'ci-sweeper-state.md',
+    primarySkill: 'ci-triage',
+    fixCapable: true,
+    intake: false,
+  },
+  'dependency-sweeper': {
+    state: 'dependency-sweeper-state.md',
+    primarySkill: 'dependency-triage',
+    fixCapable: true,
+    intake: false,
+  },
+  'post-merge-cleanup': {
+    state: 'post-merge-state.md',
+    primarySkill: 'post-merge-scan',
+    fixCapable: true,
+    intake: false,
+  },
+  'changelog-drafter': {
+    state: 'changelog-drafter-state.md',
+    primarySkill: 'changelog-scan',
+    fixCapable: false,
+    intake: false,
+  },
+  'issue-triage': {
+    state: 'issue-triage-state.md',
+    primarySkill: 'issue-triage',
+    fixCapable: false,
+    intake: true,
+  },
+};
+
+const SCAFFOLD_TOOLS = {
+  grok: ['.grok', 'skills'],
+  claude: ['.claude', 'skills'],
+  codex: ['.codex', 'skills'],
+  opencode: ['skills'],
+};
+
+async function expectPathExists(...parts) {
+  await access(path.join(...parts));
+}
+
+async function expectPathMissing(...parts) {
+  await assert.rejects(() => access(path.join(...parts)));
+}
+
+for (const [pattern, contract] of Object.entries(SCAFFOLD_PATTERNS)) {
+  for (const [tool, skillRoot] of Object.entries(SCAFFOLD_TOOLS)) {
+    test(`loop-init scaffold matrix: ${pattern} for ${tool}`, async () => {
+      const dir = await mkdtemp(path.join(tmpdir(), `loop-init-matrix-${pattern}-${tool}-`));
+      try {
+        const { stdout } = await exec('node', [
+          CLI,
+          dir,
+          '--pattern',
+          pattern,
+          '--tool',
+          tool,
+        ]);
+
+        assert.match(stdout, new RegExp(`loop-init: ${pattern}`));
+        await expectPathExists(dir, contract.state);
+        await expectPathExists(dir, 'AGENTS.md');
+        await expectPathExists(dir, 'loop-budget.md');
+        await expectPathExists(dir, 'loop-run-log.md');
+        await expectPathExists(dir, 'loop-constraints.md');
+        await expectPathExists(dir, ...skillRoot, contract.primarySkill, 'SKILL.md');
+        await expectPathExists(dir, ...skillRoot, 'loop-budget', 'SKILL.md');
+        await expectPathExists(dir, ...skillRoot, 'loop-constraints', 'SKILL.md');
+
+        if (tool === 'opencode') {
+          await expectPathExists(dir, 'opencode.json');
+        }
+
+        if (contract.fixCapable) {
+          await expectPathExists(dir, 'loop-ledger.json');
+          await expectPathExists(dir, ...skillRoot, 'minimal-fix', 'SKILL.md');
+          await expectPathExists(dir, ...skillRoot, 'loop-guard', 'SKILL.md');
+
+          const ledger = JSON.parse(await readFile(path.join(dir, 'loop-ledger.json'), 'utf8'));
+          assert.equal(ledger.pattern, pattern);
+          assert.match(ledger.level, /^L[12]$/);
+          assert.deepEqual(ledger.attempts, []);
+        } else {
+          await expectPathMissing(dir, 'loop-ledger.json');
+          await expectPathMissing(dir, ...skillRoot, 'loop-guard', 'SKILL.md');
+        }
+
+        if (contract.intake) {
+          await expectPathExists(dir, ...skillRoot, 'loop-intake', 'SKILL.md');
+        } else {
+          await expectPathMissing(dir, ...skillRoot, 'loop-intake', 'SKILL.md');
+        }
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Exercise every supported `loop-init` pattern × tool combination in a fresh
temporary directory.

## Problem

`loop-init` supports seven patterns and four tools, but the test suite sampled
only a handful of those 28 combinations. The manual validation checklist also
listed only two patterns, while `STATE.md` explicitly calls for fresh-project
validation across all patterns.

## Changes

- Add a table-driven 28-combination scaffold matrix to the existing CLI test
  process.
- Verify state, observability, constraints, the selected tool's primary skill,
  and tool-specific configuration.
- Verify circuit-breaker assets and ledger contents for fix-capable patterns,
  plus their absence from report-only patterns.
- Verify intake assets are present only for Issue Triage.
- Expand the manual validation checklist to all 28 rows and distinguish its UX
  checks from the automated contract.

## Test design

The matrix stays in the existing CLI test file because the suite's
`bundle-assets` concurrency test replaces shared bundled assets. Running a
second test file in parallel exposed a transient missing-template failure; a
single process preserves the existing serialized contract without retries.

## Testing

- [x] `cd tools/loop-init && npm test` — 53/53 passed
  - 25 existing CLI tests
  - 28 pattern × tool scaffold cases
- [x] `bash scripts/ci-validate-gates.sh`
  - full registry and tool suite passed
  - all 53 `loop-init` tests passed in the official sibling-dependency setup
- [x] `bash scripts/ci-audit-gates.sh`
  - reference score 100
  - every starter passed the L1 gate
- [x] `git diff --check`

## Scope

This PR changes tests and validation documentation only. It does not change
scaffold output, package dependencies, or runtime behavior.
