### PR TITLE
Harden loop-action command execution against unquoted shell expansion

### DIFF
--- a/tools/loop-action/README.md
+++ b/tools/loop-action/README.md
@@ -24,7 +24,7 @@ Instead of writing complex bash scripts to enforce circuit breakers, run readine
 | `command` | **Yes** | | The actual terminal command to invoke your agent (e.g., `claude`, `grok`, `aider`). |
 | `level` | No | `L1` | The autonomy level for budget constraint verification (`L1`, `L2`, `L3`). |
 | `sandbox` | No | `false` | If `'true'`, routes the execution through `loop-sandbox` to provide ephemeral worktree isolation, capturing changes securely without destroying the main working tree. |
-| `sandbox-shell` | No | `false` | If `'true'`, routes the execution inside a shell environment (`--shell`). |
+| `sandbox-shell` | No | `false` | Compatibility option for `loop-sandbox`: if `'true'`, passes `--shell` so `loop-sandbox` itself invokes the command through its own shell. `command` is always executed as a Bash script regardless of this setting (see below) — `sandbox-shell` does not gate shell syntax and can be left at its default in normal use. |
 
 ## What it does under the hood
 
@@ -32,13 +32,26 @@ When this action runs, it sequentially executes:
 1. **`loop-audit`**: Checks the repository against the Loop Readiness rubric (ensuring `STATE.md`, `gate.yaml`, and constraints are in place).
 2. **`loop-context`**: Acts as a circuit breaker. It halts the workflow immediately if the loop is stuck in a failure cycle or has exhausted its daily token budget.
 3. **Write command script**: `command` is passed through the step's `env:` map (not spliced into the `run:` script text) and written verbatim to a temp file under `$RUNNER_TEMP`. This keeps multi-line commands, quotes, and shell metacharacters intact as a single script instead of being re-parsed by the surrounding workflow YAML.
-4. **Execution (`loop-sandbox`)**: If `sandbox: 'true'`, that script is invoked as `bash <script>` inside an ephemeral git worktree via `loop-sandbox`, which tracks all modifications into a patch file and cleans up. Otherwise, it executes `bash <script>` directly in the main tree.
+4. **Execution (`loop-sandbox`)**: If `sandbox: 'true'`, that script is invoked as `bash -eo pipefail <script>` inside an ephemeral git worktree via `loop-sandbox`, which tracks all modifications into a patch file and cleans up. Otherwise, it executes `bash -eo pipefail <script>` directly in the main tree.
 
 ## Safe usage of `command`
 
-`command` is always executed as a shell script (either directly, or inside the
-`loop-sandbox` worktree). Treat it the same as any other `run:` step in a
-workflow:
+`command` is always executed as a Bash script via the temporary script file
+written in step 3 above — this is true whether `sandbox` is `'true'` or
+`'false'`, and regardless of `sandbox-shell`. The script runs with `bash -eo
+pipefail`, so:
+- any command that exits non-zero stops the script immediately (`set -e`)
+- a failing command anywhere in a pipeline fails the whole pipeline
+  (`pipefail`), not just its last stage
+
+`sandbox-shell` only controls whether `loop-sandbox` additionally routes the
+`bash <script>` invocation through its own internal shell (`--shell`) before
+running it — it is a `loop-sandbox` compatibility knob, not something you
+need to set to get shell syntax (pipes, `&&`, multi-line scripts, etc.) in
+`command`. Those already work through the temporary script regardless of
+`sandbox-shell`.
+
+Treat `command` the same as any other `run:` step in a workflow:
 
 ```yaml
 - uses: cobusgreyling/loop-engineering/tools/loop-action@main

--- a/tools/loop-action/README.md
+++ b/tools/loop-action/README.md
@@ -31,4 +31,37 @@ Instead of writing complex bash scripts to enforce circuit breakers, run readine
 When this action runs, it sequentially executes:
 1. **`loop-audit`**: Checks the repository against the Loop Readiness rubric (ensuring `STATE.md`, `gate.yaml`, and constraints are in place).
 2. **`loop-context`**: Acts as a circuit breaker. It halts the workflow immediately if the loop is stuck in a failure cycle or has exhausted its daily token budget.
-3. **Execution (`loop-sandbox`)**: If `sandbox: 'true'`, it dynamically isolates the agent inside an ephemeral git worktree, tracks all modifications into a patch file, and cleans up. Otherwise, it executes the command directly in the main tree.
+3. **Write command script**: `command` is passed through the step's `env:` map (not spliced into the `run:` script text) and written verbatim to a temp file under `$RUNNER_TEMP`. This keeps multi-line commands, quotes, and shell metacharacters intact as a single script instead of being re-parsed by the surrounding workflow YAML.
+4. **Execution (`loop-sandbox`)**: If `sandbox: 'true'`, that script is invoked as `bash <script>` inside an ephemeral git worktree via `loop-sandbox`, which tracks all modifications into a patch file and cleans up. Otherwise, it executes `bash <script>` directly in the main tree.
+
+## Safe usage of `command`
+
+`command` is always executed as a shell script (either directly, or inside the
+`loop-sandbox` worktree). Treat it the same as any other `run:` step in a
+workflow:
+
+```yaml
+- uses: cobusgreyling/loop-engineering/tools/loop-action@main
+  with:
+    pattern: 'ci-sweeper'
+    level: 'L2'
+    sandbox: 'true'
+    command: |
+      npx grok-cli run --skill .grok/skills/ci-sweeper/SKILL.md
+      echo "done"
+```
+
+Multi-line `command: |` blocks are supported and run as a single atomic
+script — every line executes inside the chosen path (sandbox or direct), not
+just the first.
+
+> **Warning — never embed untrusted input directly in `command`.**
+> Do not interpolate values from issue titles/bodies, PR titles/bodies, commit
+> messages, branch names, or any other content an external, untrusted actor
+> can influence (e.g. `command: 'echo ${{ github.event.issue.title }}'`).
+> `command` runs as an arbitrary shell script with the permissions of the
+> job, so untrusted text placed in it is a shell/command injection
+> vulnerability regardless of how the action passes the string internally.
+> If you need data from the triggering event, pass it through an
+> intermediate step that validates/escapes it (or write it to a file and
+> have your agent read the file) instead of splicing it into `command`.

--- a/tools/loop-action/action.yml
+++ b/tools/loop-action/action.yml
@@ -43,7 +43,6 @@ runs:
       run: |
         script_path="$(mktemp "${RUNNER_TEMP:-/tmp}/loop-action-command.XXXXXX")"
         printf '%s\n' "$LOOP_COMMAND" > "$script_path"
-        chmod +x "$script_path"
         echo "script-path=$script_path" >> "$GITHUB_OUTPUT"
       shell: bash
 
@@ -54,9 +53,9 @@ runs:
         LOOP_SANDBOX_SHELL: ${{ inputs.sandbox-shell }}
       run: |
         if [ "$LOOP_SANDBOX_SHELL" == "true" ]; then
-          npx --yes @cobusgreyling/loop-sandbox run --shell -- bash "$LOOP_SCRIPT_PATH"
+          npx --yes @cobusgreyling/loop-sandbox run --shell -- bash -eo pipefail "$LOOP_SCRIPT_PATH"
         else
-          npx --yes @cobusgreyling/loop-sandbox run -- bash "$LOOP_SCRIPT_PATH"
+          npx --yes @cobusgreyling/loop-sandbox run -- bash -eo pipefail "$LOOP_SCRIPT_PATH"
         fi
       shell: bash
 
@@ -64,5 +63,5 @@ runs:
       if: ${{ inputs.sandbox != 'true' }}
       env:
         LOOP_SCRIPT_PATH: ${{ steps.write_command.outputs.script-path }}
-      run: bash "$LOOP_SCRIPT_PATH"
+      run: bash -eo pipefail "$LOOP_SCRIPT_PATH"
       shell: bash

--- a/tools/loop-action/action.yml
+++ b/tools/loop-action/action.yml
@@ -36,17 +36,33 @@ runs:
           --budget-from-pattern ${{ inputs.pattern }} --budget-level ${{ inputs.level }}
       shell: bash
 
+    - name: Write Agent Command Script
+      id: write_command
+      env:
+        LOOP_COMMAND: ${{ inputs.command }}
+      run: |
+        script_path="$(mktemp "${RUNNER_TEMP:-/tmp}/loop-action-command.XXXXXX")"
+        printf '%s\n' "$LOOP_COMMAND" > "$script_path"
+        chmod +x "$script_path"
+        echo "script-path=$script_path" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Run Agent (Sandbox)
       if: ${{ inputs.sandbox == 'true' }}
+      env:
+        LOOP_SCRIPT_PATH: ${{ steps.write_command.outputs.script-path }}
+        LOOP_SANDBOX_SHELL: ${{ inputs.sandbox-shell }}
       run: |
-        if [ "${{ inputs.sandbox-shell }}" == "true" ]; then
-          npx --yes @cobusgreyling/loop-sandbox run --shell -- ${{ inputs.command }}
+        if [ "$LOOP_SANDBOX_SHELL" == "true" ]; then
+          npx --yes @cobusgreyling/loop-sandbox run --shell -- bash "$LOOP_SCRIPT_PATH"
         else
-          npx --yes @cobusgreyling/loop-sandbox run -- ${{ inputs.command }}
+          npx --yes @cobusgreyling/loop-sandbox run -- bash "$LOOP_SCRIPT_PATH"
         fi
       shell: bash
 
     - name: Run Agent (Direct)
       if: ${{ inputs.sandbox != 'true' }}
-      run: ${{ inputs.command }}
+      env:
+        LOOP_SCRIPT_PATH: ${{ steps.write_command.outputs.script-path }}
+      run: bash "$LOOP_SCRIPT_PATH"
       shell: bash


### PR DESCRIPTION
## Summary

Same change as #395 (from @amarjaleelbanbhan), re-hosted on a same-repo branch so required `audit` / `validate` checks can run (fork PR workflows were stuck in `action_required`).

`inputs.command` was spliced as raw text into the `run:` script before bash parsed it. For multi-line `command: |` blocks this silently broke sandbox isolation: only the first line reached `loop-sandbox run -- ...`; every later line executed as a bare top-level statement on the runner, bypassing the sandbox and circuit-breaker entirely.

Write `command` to a temp script (passed via `env:`, never re-templated by the workflow YAML) and invoke it as a single quoted `bash -eo pipefail "$SCRIPT"` call from both the sandbox and direct paths. Document safe usage and warn against embedding untrusted input in `command` in the README.

Closes #395 (supersedes / merges the same commits).

## Attribution

- Original PR: https://github.com/cobusgreyling/loop-engineering/pull/395
- Author: @amarjaleelbanbhan

## Checklist

- [x] Security-sensitive command handling documented
- [x] Fail-fast (`bash -eo pipefail`) on all execution paths