### PR TITLE
docs(quickstart): fix loop-gate subsection — valid yaml, complete exa…

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -146,6 +146,33 @@ LOOP_PROJECT_ROOT=/path/to/your/project node dist/index.js
 
 See [tools/mcp-server/README.md](../tools/mcp-server/README.md) for resources and tools.
 
+## 4b. Set the merge gate (30 seconds)
+
+Before any loop can auto-merge, it needs a `gate.yaml` defining what's off-limits and what's safe to merge unattended. Copy the starter from [templates/gate.yaml.template](../templates/gate.yaml.template) into your repo root as `gate.yaml`:
+
+```yaml
+version: 1
+denylist:
+  - "src/auth/**"
+  - "**/*.env"
+autoMergeAllowlist:
+  - "docs/**"
+  - "**/*.md"
+```
+
+This is **not** a free-form list of gates — `denylist` and `autoMergeAllowlist` are fixed keys `loop-gate` checks against (there's also an optional `maxFiles` cap — see the full template for details).
+
+Enforce it mechanically before any auto-merge action:
+
+```bash
+npx @cobusgreyling/loop gate check --action auto-merge --paths <f1,f2,...>
+# same as: npx @cobusgreyling/loop-gate check --action auto-merge --paths <f1,f2,...>
+```
+
+Exit `0` = allowed · `2` = escalate to a human. Already running `loop-audit --auto-fix`? It emits a loadable `gate.yaml` for you automatically — no need to hand-write one.
+
+See [tools/loop-gate/README.md](../tools/loop-gate/README.md) for the full policy schema and [docs/safety.md](./safety.md) for the risk/mitigation model this gate enforces.
+
 ## 5. Run your first loop — report only (2 minutes)
 
 ### Grok


### PR DESCRIPTION
## Summary
Adds a "Set the merge gate" subsection to `docs/QUICKSTART.md` so the `denylist` / `autoMergeAllowlist` schema in `gate.yaml` is discoverable right next to the rest of the onboarding flow, instead of only living in `tools/loop-gate/README.md`. Closes #391.

## Changes
- [x] Doc / example improvement
- [ ] New pattern or starter
- [ ] Tool change (loop-audit)
- [ ] Story

Added a new `## 4b. Set the merge gate` section between "Audit readiness" and "Run your first loop", covering:
- The `npx @cobusgreyling/loop-gate check --action auto-merge --paths …` command
- The actual `version: 1` / `denylist` / `autoMergeAllowlist` schema (matching `templates/gate.yaml.template`, not a free-form gates list)
- A note that `loop-audit --auto-fix` emits a loadable `gate.yaml` automatically
- Cross-links to `tools/loop-gate/README.md` and `docs/safety.md`

## Checklist (from CONTRIBUTING)
- [x] All required sections present for patterns *(N/A — docs-only change, no new pattern)*
- [x] Links work from README, patterns/README, starters/README, docs/index — verified `../templates/gate.yaml.template`, `../tools/loop-gate/README.md`, and `./safety.md` resolve correctly from `docs/QUICKSTART.md`
- [x] No secrets, tokens, internal company URLs
- [x] `STATE.md*` examples use `.example` suffix *(N/A — no STATE.md examples touched)*
- [x] Safety-related content references `docs/safety.md`
- [x] Ran `node tools/loop-audit/dist/cli.js .` and addressed findings

## Testing / Dogfood
- [x] `loop-audit` passes on this repo
- [x] Manual review — previewed the rendered markdown locally (VS Code preview) and confirmed the YAML block is valid and copy-pasteable

## Screenshots / Examples (if UI or command output)
New subsection renders as:

> **4b. Set the merge gate (30 seconds)**
> Before any loop can auto-merge, it needs a `gate.yaml`... [full schema example + `loop-gate check` command + links to `tools/loop-gate/` and `docs/safety.md`]

---

*This template enforces the high bar this reference is known for.*
