### PR TITLE
feat(loop-init): add MiniMax provider option for --with-foundry implementer stacks

### DIFF
--- a/tools/loop-init/CHANGELOG.md
+++ b/tools/loop-init/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `@cobusgreyling/loop-init` are documented here.
 
+## [Unreleased]
+
+### Added
+- `--model-provider minimax` for `--with-foundry` implementer stacks — emits a `model/minimax` provider primitive instead of the default interface primitive
+  - Global (`global_en`) and China (`cn_zh`) endpoint configuration in every generated stack
+  - `MiniMax-M3` (default) and `MiniMax-M2.7` model options with context window, input modalities, thinking modes, and pricing
+- `--region` (`global_en`, `cn_zh`) and `--model` (`MiniMax-M3`, `MiniMax-M2.7`) flags to select the active MiniMax region and model
+- Help text and examples for the new flags
+
 ## [1.5.0] - 2026-07-20
 
 ### Added

--- a/tools/loop-init/README.md
+++ b/tools/loop-init/README.md
@@ -38,6 +38,23 @@ npx @cobusgreyling/harness-foundry init --from loop-engineering:daily-triage
 
 Every `loop-init` run prints a Foundry CTA; when Loop Ready is **≥ 80**, the CTA is emphasized as the next step after design.
 
+### Interface provider (implementer preset)
+
+The `implementer` preset defaults to the built-in interface primitive. Pass `--model-provider minimax` to emit a `model/minimax` provider primitive instead. The generated stack always carries both regional endpoints and both model options, so you can switch region/model without regenerating:
+
+```bash
+npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax
+npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax --region cn_zh --model MiniMax-M2.7
+```
+
+| Flag | Values | Default |
+|------|--------|---------|
+| `--model-provider` | `anthropic`, `minimax` | `anthropic` |
+| `--region` | `global_en`, `cn_zh` | `global_en` |
+| `--model` | `MiniMax-M3`, `MiniMax-M2.7` | `MiniMax-M3` |
+
+MiniMax model options and both endpoints (`global_en` → `https://api.minimax.io`, `cn_zh` → `https://api.minimaxi.com`) are written into `.foundry/stack.yaml`.
+
 ## Patterns
 
 | Pattern | Default state file |

--- a/tools/loop-init/dist/cli.js
+++ b/tools/loop-init/dist/cli.js
@@ -66,6 +66,68 @@ const PATTERN_FOUNDRY_PRESET = {
     'post-merge-cleanup': 'implementer',
 };
 const FOUNDRY_SHOWCASE = 'https://github.com/cobusgreyling/harness-foundry/blob/main/docs/showcase.md';
+const MINIMAX_DEFAULT_MODEL = 'MiniMax-M3';
+const MINIMAX_DEFAULT_REGION = 'global_en';
+const MINIMAX_MODELS = [
+    {
+        id: 'MiniMax-M3',
+        contextWindow: 1_000_000,
+        inputModalities: ['text', 'image', 'video'],
+        thinking: ['adaptive', 'disabled'],
+        pricing: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: null },
+    },
+    {
+        id: 'MiniMax-M2.7',
+        contextWindow: 204_800,
+        inputModalities: ['text'],
+        thinking: ['always_on'],
+        pricing: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
+    },
+];
+const MINIMAX_REGIONS = [
+    {
+        region: 'global_en',
+        openaiBaseUrl: 'https://api.minimax.io/v1',
+        anthropicBaseUrl: 'https://api.minimax.io/anthropic',
+        docsRoot: 'https://platform.minimax.io/docs',
+    },
+    {
+        region: 'cn_zh',
+        openaiBaseUrl: 'https://api.minimaxi.com/v1',
+        anthropicBaseUrl: 'https://api.minimaxi.com/anthropic',
+        docsRoot: 'https://platform.minimaxi.com/docs',
+    },
+];
+const MINIMAX_MODEL_IDS = MINIMAX_MODELS.map((m) => m.id);
+const MINIMAX_REGION_IDS = MINIMAX_REGIONS.map((r) => r.region);
+/** Render the `model/minimax` interface primitive for the implementer stack. */
+function minimaxInterfaceYaml(model, region) {
+    const models = MINIMAX_MODELS.map((m) => [
+        `          - id: ${m.id}`,
+        `            context_window: ${m.contextWindow}`,
+        `            input_modalities: [${m.inputModalities.join(', ')}]`,
+        `            thinking: [${m.thinking.join(', ')}]`,
+        `            pricing_usd_per_million_tokens:`,
+        `              input: ${m.pricing.input}`,
+        `              output: ${m.pricing.output}`,
+        `              cache_read: ${m.pricing.cacheRead}`,
+        `              cache_write: ${m.pricing.cacheWrite === null ? 'null' : m.pricing.cacheWrite}`,
+    ].join('\n')).join('\n');
+    const endpoints = MINIMAX_REGIONS.map((r) => [
+        `          ${r.region}:`,
+        `            openai_base_url: ${r.openaiBaseUrl}`,
+        `            anthropic_base_url: ${r.anthropicBaseUrl}`,
+        `            docs_root: ${r.docsRoot}`,
+    ].join('\n')).join('\n');
+    return `    - primitive: model/minimax
+      config:
+        model: ${model}
+        region: ${region}
+        models:
+${models}
+        endpoints:
+${endpoints}`;
+}
 function parseArgs(argv) {
     let pattern = 'daily-triage';
     let tool = 'grok';
@@ -74,6 +136,9 @@ function parseArgs(argv) {
     let withFoundry = false;
     let withMemory = false;
     let withFleet = false;
+    let modelProvider = 'anthropic';
+    let region = MINIMAX_DEFAULT_REGION;
+    let model = MINIMAX_DEFAULT_MODEL;
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i];
         if (a === '--pattern' || a === '-p')
@@ -88,23 +153,32 @@ function parseArgs(argv) {
             withMemory = true;
         else if (a === '--with-fleet')
             withFleet = true;
+        else if (a === '--model-provider')
+            modelProvider = argv[++i];
+        else if (a === '--region')
+            region = argv[++i];
+        else if (a === '--model')
+            model = argv[++i];
         else if (a === '--help' || a === '-h')
-            return { help: true, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet };
+            return { help: true, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet, modelProvider, region, model };
         else if (!a.startsWith('-'))
             target = a;
     }
-    return { help: false, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet };
+    return { help: false, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet, modelProvider, region, model };
 }
-function foundryStackYaml(stackName, pattern, preset) {
+function foundryStackYaml(stackName, pattern, preset, provider = 'anthropic', region = MINIMAX_DEFAULT_REGION, model = MINIMAX_DEFAULT_MODEL) {
     if (preset === 'implementer') {
+        const interfaceLayer = provider === 'minimax'
+            ? minimaxInterfaceYaml(model, region)
+            : `    - primitive: model/anthropic
+      config:
+        model: claude-sonnet-4-20250514`;
         return `name: ${stackName}
 version: 1.0.0
 description: "loop-engineering ${pattern} → implementer harness (loop-init --with-foundry)"
 layers:
   interface:
-    - primitive: model/anthropic
-      config:
-        model: claude-sonnet-4-20250514
+${interfaceLayer}
   composition:
     - primitive: context/state-file
     - primitive: tools/git-worktree-write
@@ -137,7 +211,11 @@ layers:
  * Scaffold a harness-foundry stack next to loop files so LE graduates land in
  * a versioned harness in one command (no foundry package dependency).
  */
-async function scaffoldFoundry(pattern, targetDir, dryRun) {
+async function scaffoldFoundry(pattern, targetDir, dryRun, model = {
+    provider: 'anthropic',
+    region: MINIMAX_DEFAULT_REGION,
+    model: MINIMAX_DEFAULT_MODEL,
+}) {
     const preset = PATTERN_FOUNDRY_PRESET[pattern];
     const foundryRoot = path.join(targetDir, '.foundry');
     const stackFile = path.join(foundryRoot, 'stack.yaml');
@@ -147,7 +225,7 @@ async function scaffoldFoundry(pattern, targetDir, dryRun) {
         return { preset, stackFile };
     }
     const files = [
-        { path: stackFile, content: foundryStackYaml(stackName, pattern, preset) },
+        { path: stackFile, content: foundryStackYaml(stackName, pattern, preset, model.provider, model.region, model.model) },
         {
             path: path.join(foundryRoot, 'hooks', 'outerloop.yaml'),
             content: `enabled: false
@@ -591,6 +669,9 @@ Options:
   --with-foundry    Also scaffold .foundry/ stack (harness-foundry runtime)
   --with-memory     Also scaffold memory-engineering tiers and budget
   --with-fleet      Also scaffold fleet-engineering registry and inbox
+  --model-provider  Implementer interface provider (default: anthropic; minimax)
+  --region          MiniMax region when --model-provider minimax (global_en, cn_zh)
+  --model           MiniMax model when --model-provider minimax (MiniMax-M3, MiniMax-M2.7)
   --dry-run         Print actions without copying
   -h, --help        This help
 
@@ -602,13 +683,15 @@ Examples:
   npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok
   npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok --with-foundry
   npx @cobusgreyling/loop-init . -p pr-babysitter -t claude --with-foundry
+  npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax
+  npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax --region cn_zh --model MiniMax-M2.7
   npx @cobusgreyling/loop-init . -p daily-triage -t opencode
   npx @cobusgreyling/loop-init . --with-memory
   npx @cobusgreyling/loop-init . --with-fleet
 `);
         process.exit(0);
     }
-    const { pattern, tool, target, dryRun, withFoundry, withMemory, withFleet } = args;
+    const { pattern, tool, target, dryRun, withFoundry, withMemory, withFleet, modelProvider, region, model } = args;
     const validPatterns = Object.keys(PATTERN_STARTERS);
     const validTools = Object.keys(TOOL_SUFFIX);
     if (!validPatterns.includes(pattern)) {
@@ -618,6 +701,21 @@ Examples:
     if (!validTools.includes(tool)) {
         console.error(`Unknown tool: ${tool}. Valid: ${validTools.join(', ')}`);
         process.exit(1);
+    }
+    const validProviders = ['anthropic', 'minimax'];
+    if (!validProviders.includes(modelProvider)) {
+        console.error(`Unknown model provider: ${modelProvider}. Valid: ${validProviders.join(', ')}`);
+        process.exit(1);
+    }
+    if (modelProvider === 'minimax') {
+        if (!MINIMAX_REGION_IDS.includes(region)) {
+            console.error(`Unknown region: ${region}. Valid: ${MINIMAX_REGION_IDS.join(', ')}`);
+            process.exit(1);
+        }
+        if (!MINIMAX_MODEL_IDS.includes(model)) {
+            console.error(`Unknown model: ${model}. Valid: ${MINIMAX_MODEL_IDS.join(', ')}`);
+            process.exit(1);
+        }
     }
     const targetDir = path.resolve(target);
     const baseStarter = PATTERN_STARTERS[pattern];
@@ -725,7 +823,11 @@ npm run lint
     if (withFoundry) {
         console.log('');
         console.log('Harness foundry:');
-        const foundry = await scaffoldFoundry(pattern, targetDir, dryRun);
+        const foundry = await scaffoldFoundry(pattern, targetDir, dryRun, {
+            provider: modelProvider,
+            region,
+            model,
+        });
         foundryPreset = foundry?.preset;
     }
     if (withMemory) {

--- a/tools/loop-init/src/cli.ts
+++ b/tools/loop-init/src/cli.ts
@@ -94,6 +94,108 @@ const PATTERN_FOUNDRY_PRESET: Record<Pattern, FoundryPreset> = {
 const FOUNDRY_SHOWCASE =
   'https://github.com/cobusgreyling/harness-foundry/blob/main/docs/showcase.md';
 
+/**
+ * Model providers selectable for the implementer preset's `interface` layer.
+ * The implementer stack defaults to the existing primitive; `minimax` emits a
+ * `model/minimax` provider primitive with regional endpoints and model options.
+ */
+type ModelProvider = 'anthropic' | 'minimax';
+
+type MiniMaxRegion = 'global_en' | 'cn_zh';
+
+interface MiniMaxModel {
+  id: string;
+  contextWindow: number;
+  inputModalities: string[];
+  thinking: string[];
+  pricing: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number | null;
+  };
+}
+
+interface MiniMaxRegionEndpoint {
+  region: MiniMaxRegion;
+  openaiBaseUrl: string;
+  anthropicBaseUrl: string;
+  docsRoot: string;
+}
+
+const MINIMAX_DEFAULT_MODEL = 'MiniMax-M3';
+const MINIMAX_DEFAULT_REGION: MiniMaxRegion = 'global_en';
+
+const MINIMAX_MODELS: MiniMaxModel[] = [
+  {
+    id: 'MiniMax-M3',
+    contextWindow: 1_000_000,
+    inputModalities: ['text', 'image', 'video'],
+    thinking: ['adaptive', 'disabled'],
+    pricing: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: null },
+  },
+  {
+    id: 'MiniMax-M2.7',
+    contextWindow: 204_800,
+    inputModalities: ['text'],
+    thinking: ['always_on'],
+    pricing: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
+  },
+];
+
+const MINIMAX_REGIONS: MiniMaxRegionEndpoint[] = [
+  {
+    region: 'global_en',
+    openaiBaseUrl: 'https://api.minimax.io/v1',
+    anthropicBaseUrl: 'https://api.minimax.io/anthropic',
+    docsRoot: 'https://platform.minimax.io/docs',
+  },
+  {
+    region: 'cn_zh',
+    openaiBaseUrl: 'https://api.minimaxi.com/v1',
+    anthropicBaseUrl: 'https://api.minimaxi.com/anthropic',
+    docsRoot: 'https://platform.minimaxi.com/docs',
+  },
+];
+
+const MINIMAX_MODEL_IDS = MINIMAX_MODELS.map((m) => m.id);
+const MINIMAX_REGION_IDS = MINIMAX_REGIONS.map((r) => r.region);
+
+/** Render the `model/minimax` interface primitive for the implementer stack. */
+function minimaxInterfaceYaml(model: string, region: MiniMaxRegion): string {
+  const models = MINIMAX_MODELS.map((m) =>
+    [
+      `          - id: ${m.id}`,
+      `            context_window: ${m.contextWindow}`,
+      `            input_modalities: [${m.inputModalities.join(', ')}]`,
+      `            thinking: [${m.thinking.join(', ')}]`,
+      `            pricing_usd_per_million_tokens:`,
+      `              input: ${m.pricing.input}`,
+      `              output: ${m.pricing.output}`,
+      `              cache_read: ${m.pricing.cacheRead}`,
+      `              cache_write: ${m.pricing.cacheWrite === null ? 'null' : m.pricing.cacheWrite}`,
+    ].join('\n'),
+  ).join('\n');
+
+  const endpoints = MINIMAX_REGIONS.map((r) =>
+    [
+      `          ${r.region}:`,
+      `            openai_base_url: ${r.openaiBaseUrl}`,
+      `            anthropic_base_url: ${r.anthropicBaseUrl}`,
+      `            docs_root: ${r.docsRoot}`,
+    ].join('\n'),
+  ).join('\n');
+
+  return `    - primitive: model/minimax
+      config:
+        model: ${model}
+        region: ${region}
+        models:
+${models}
+        endpoints:
+${endpoints}`;
+}
+
 function parseArgs(argv: string[]) {
   let pattern: Pattern = 'daily-triage';
   let tool: Tool = 'grok';
@@ -102,6 +204,9 @@ function parseArgs(argv: string[]) {
   let withFoundry = false;
   let withMemory = false;
   let withFleet = false;
+  let modelProvider: ModelProvider = 'anthropic';
+  let region: MiniMaxRegion = MINIMAX_DEFAULT_REGION;
+  let model = MINIMAX_DEFAULT_MODEL;
 
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -111,24 +216,38 @@ function parseArgs(argv: string[]) {
     else if (a === '--with-foundry') withFoundry = true;
     else if (a === '--with-memory') withMemory = true;
     else if (a === '--with-fleet') withFleet = true;
+    else if (a === '--model-provider') modelProvider = argv[++i] as ModelProvider;
+    else if (a === '--region') region = argv[++i] as MiniMaxRegion;
+    else if (a === '--model') model = argv[++i];
     else if (a === '--help' || a === '-h')
-      return { help: true as const, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet };
+      return { help: true as const, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet, modelProvider, region, model };
     else if (!a.startsWith('-')) target = a;
   }
 
-  return { help: false as const, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet };
+  return { help: false as const, pattern, tool, target, dryRun, withFoundry, withMemory, withFleet, modelProvider, region, model };
 }
 
-function foundryStackYaml(stackName: string, pattern: Pattern, preset: FoundryPreset): string {
+function foundryStackYaml(
+  stackName: string,
+  pattern: Pattern,
+  preset: FoundryPreset,
+  provider: ModelProvider = 'anthropic',
+  region: MiniMaxRegion = MINIMAX_DEFAULT_REGION,
+  model: string = MINIMAX_DEFAULT_MODEL,
+): string {
   if (preset === 'implementer') {
+    const interfaceLayer =
+      provider === 'minimax'
+        ? minimaxInterfaceYaml(model, region)
+        : `    - primitive: model/anthropic
+      config:
+        model: claude-sonnet-4-20250514`;
     return `name: ${stackName}
 version: 1.0.0
 description: "loop-engineering ${pattern} → implementer harness (loop-init --with-foundry)"
 layers:
   interface:
-    - primitive: model/anthropic
-      config:
-        model: claude-sonnet-4-20250514
+${interfaceLayer}
   composition:
     - primitive: context/state-file
     - primitive: tools/git-worktree-write
@@ -167,6 +286,11 @@ async function scaffoldFoundry(
   pattern: Pattern,
   targetDir: string,
   dryRun: boolean,
+  model: { provider: ModelProvider; region: MiniMaxRegion; model: string } = {
+    provider: 'anthropic',
+    region: MINIMAX_DEFAULT_REGION,
+    model: MINIMAX_DEFAULT_MODEL,
+  },
 ): Promise<{ preset: FoundryPreset; stackFile: string } | null> {
   const preset = PATTERN_FOUNDRY_PRESET[pattern];
   const foundryRoot = path.join(targetDir, '.foundry');
@@ -179,7 +303,7 @@ async function scaffoldFoundry(
   }
 
   const files: Array<{ path: string; content: string }> = [
-    { path: stackFile, content: foundryStackYaml(stackName, pattern, preset) },
+    { path: stackFile, content: foundryStackYaml(stackName, pattern, preset, model.provider, model.region, model.model) },
     {
       path: path.join(foundryRoot, 'hooks', 'outerloop.yaml'),
       content: `enabled: false
@@ -735,6 +859,9 @@ Options:
   --with-foundry    Also scaffold .foundry/ stack (harness-foundry runtime)
   --with-memory     Also scaffold memory-engineering tiers and budget
   --with-fleet      Also scaffold fleet-engineering registry and inbox
+  --model-provider  Implementer interface provider (default: anthropic; minimax)
+  --region          MiniMax region when --model-provider minimax (global_en, cn_zh)
+  --model           MiniMax model when --model-provider minimax (MiniMax-M3, MiniMax-M2.7)
   --dry-run         Print actions without copying
   -h, --help        This help
 
@@ -746,6 +873,8 @@ Examples:
   npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok
   npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok --with-foundry
   npx @cobusgreyling/loop-init . -p pr-babysitter -t claude --with-foundry
+  npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax
+  npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax --region cn_zh --model MiniMax-M2.7
   npx @cobusgreyling/loop-init . -p daily-triage -t opencode
   npx @cobusgreyling/loop-init . --with-memory
   npx @cobusgreyling/loop-init . --with-fleet
@@ -753,7 +882,7 @@ Examples:
     process.exit(0);
   }
 
-  const { pattern, tool, target, dryRun, withFoundry, withMemory, withFleet } = args;
+  const { pattern, tool, target, dryRun, withFoundry, withMemory, withFleet, modelProvider, region, model } = args;
 
   const validPatterns = Object.keys(PATTERN_STARTERS) as Pattern[];
   const validTools = Object.keys(TOOL_SUFFIX) as Tool[];
@@ -764,6 +893,21 @@ Examples:
   if (!validTools.includes(tool)) {
     console.error(`Unknown tool: ${tool}. Valid: ${validTools.join(', ')}`);
     process.exit(1);
+  }
+  const validProviders: ModelProvider[] = ['anthropic', 'minimax'];
+  if (!validProviders.includes(modelProvider)) {
+    console.error(`Unknown model provider: ${modelProvider}. Valid: ${validProviders.join(', ')}`);
+    process.exit(1);
+  }
+  if (modelProvider === 'minimax') {
+    if (!MINIMAX_REGION_IDS.includes(region)) {
+      console.error(`Unknown region: ${region}. Valid: ${MINIMAX_REGION_IDS.join(', ')}`);
+      process.exit(1);
+    }
+    if (!MINIMAX_MODEL_IDS.includes(model)) {
+      console.error(`Unknown model: ${model}. Valid: ${MINIMAX_MODEL_IDS.join(', ')}`);
+      process.exit(1);
+    }
   }
 
   const targetDir = path.resolve(target);
@@ -890,7 +1034,11 @@ npm run lint
   if (withFoundry) {
     console.log('');
     console.log('Harness foundry:');
-    const foundry = await scaffoldFoundry(pattern, targetDir, dryRun);
+    const foundry = await scaffoldFoundry(pattern, targetDir, dryRun, {
+      provider: modelProvider,
+      region,
+      model,
+    });
     foundryPreset = foundry?.preset;
   }
 

--- a/tools/loop-init/test/cli.test.mjs
+++ b/tools/loop-init/test/cli.test.mjs
@@ -271,6 +271,134 @@ test('loop-init --help documents --with-foundry', async () => {
   assert.match(stdout, /harness-foundry|implementer|minimal/);
 });
 
+test('loop-init --with-foundry --model-provider minimax emits MiniMax provider primitive', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loop-init-foundry-minimax-'));
+  try {
+    const { stdout } = await exec('node', [
+      CLI,
+      dir,
+      '--pattern',
+      'ci-sweeper',
+      '--tool',
+      'grok',
+      '--with-foundry',
+      '--model-provider',
+      'minimax',
+    ]);
+    const stack = await readFile(path.join(dir, '.foundry', 'stack.yaml'), 'utf8');
+    assert.match(stack, /primitive: model\/minimax/);
+    assert.match(stack, /model: MiniMax-M3/);
+    assert.match(stack, /- id: MiniMax-M3/);
+    assert.match(stack, /- id: MiniMax-M2\.7/);
+    assert.match(stack, /region: global_en/);
+    // global endpoint
+    assert.match(stack, /https:\/\/api\.minimax\.io\/v1/);
+    // CN endpoint
+    assert.match(stack, /https:\/\/api\.minimaxi\.com\/v1/);
+    assert.doesNotMatch(stack, /model\/anthropic/);
+    assert.match(stdout, /preset: implementer/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loop-init --with-foundry minimax --region cn_zh selects CN region and model', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loop-init-foundry-minimax-cn-'));
+  try {
+    await exec('node', [
+      CLI,
+      dir,
+      '--pattern',
+      'ci-sweeper',
+      '--tool',
+      'grok',
+      '--with-foundry',
+      '--model-provider',
+      'minimax',
+      '--region',
+      'cn_zh',
+      '--model',
+      'MiniMax-M2.7',
+    ]);
+    const stack = await readFile(path.join(dir, '.foundry', 'stack.yaml'), 'utf8');
+    assert.match(stack, /region: cn_zh/);
+    assert.match(stack, /model: MiniMax-M2\.7/);
+    // both regional endpoints remain available in config
+    assert.match(stack, /global_en:/);
+    assert.match(stack, /cn_zh:/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loop-init --with-foundry anthropic provider is unchanged (default)', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loop-init-foundry-default-'));
+  try {
+    await exec('node', [
+      CLI,
+      dir,
+      '--pattern',
+      'ci-sweeper',
+      '--tool',
+      'grok',
+      '--with-foundry',
+    ]);
+    const stack = await readFile(path.join(dir, '.foundry', 'stack.yaml'), 'utf8');
+    assert.match(stack, /model\/anthropic/);
+    assert.doesNotMatch(stack, /model\/minimax/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loop-init rejects unknown model provider', async () => {
+  await assert.rejects(
+    () =>
+      exec('node', [
+        CLI,
+        '.',
+        '--pattern',
+        'ci-sweeper',
+        '--tool',
+        'grok',
+        '--with-foundry',
+        '--model-provider',
+        'not-a-provider',
+        '--dry-run',
+      ]),
+    (err) =>
+      err.stderr?.includes('Unknown model provider') ||
+      err.message?.includes('Unknown model provider'),
+  );
+});
+
+test('loop-init rejects unknown minimax model', async () => {
+  await assert.rejects(
+    () =>
+      exec('node', [
+        CLI,
+        '.',
+        '--pattern',
+        'ci-sweeper',
+        '--tool',
+        'grok',
+        '--with-foundry',
+        '--model-provider',
+        'minimax',
+        '--model',
+        'not-a-model',
+        '--dry-run',
+      ]),
+    (err) => err.stderr?.includes('Unknown model') || err.message?.includes('Unknown model'),
+  );
+});
+
+test('loop-init --help documents --model-provider minimax', async () => {
+  const { stdout } = await exec('node', [CLI, '--help']);
+  assert.match(stdout, /--model-provider/);
+  assert.match(stdout, /minimax/);
+});
+
 test('loop-init prints memory CTA without --with-memory', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'loop-init-mem-cta-'));
   try {


### PR DESCRIPTION
Reason: loop-init's `--with-foundry` implementer preset had no MiniMax provider primitive, no global/CN endpoint configuration, and no MiniMax-M3 / MiniMax-M2.7 model options.

## What changed

`tools/loop-init` now lets the implementer preset target MiniMax when generating a harness stack.

- New `--model-provider minimax` flag: emits a `model/minimax` provider primitive in `.foundry/stack.yaml` instead of the default interface primitive.
- The generated stack always carries both regional endpoints so a stack can switch region without regeneration:
  - `global_en` -> `https://api.minimax.io/v1` (OpenAI-compatible) / `https://api.minimax.io/anthropic`
  - `cn_zh` -> `https://api.minimaxi.com/v1` / `https://api.minimaxi.com/anthropic`
- Two model options with context window, input modalities, thinking modes, and pricing:
  - `MiniMax-M3` (default) - 1,000,000 context, text/image/video, adaptive/disabled thinking
  - `MiniMax-M2.7` - 204,800 context, text, always-on thinking
- New `--region` (`global_en`, `cn_zh`) and `--model` (`MiniMax-M3`, `MiniMax-M2.7`) flags select the active region and model, with validation.
- Default behavior is unchanged: without `--model-provider minimax`, the implementer preset still emits its existing interface primitive.
- Help text, README, and CHANGELOG updated; `dist/` rebuilt from source.

## Checks

Run in `tools/loop-init`:

- `npm run build` - bundle assets + `tsc` (clean)
- `npm test` - `node --test test/cli.test.mjs`: 58 pass, including 6 new tests covering the MiniMax primitive, region/model selection, unchanged default, and rejection of unknown provider/model. The one unrelated failure (`prints Loop Ready score after scaffold`) is pre-existing and depends on the external `loop-audit` binary being reachable; it fails identically on the base branch in this offline environment.
- Generated `stack.yaml` validated as well-formed YAML.
