### PR TITLE
chore: publish queue — version bumps + sandbox/swarm release workflows

### DIFF
--- a/.github/workflows/release-loop-sandbox.yml
+++ b/.github/workflows/release-loop-sandbox.yml
@@ -1,0 +1,63 @@
+name: Release loop-sandbox
+
+on:
+  push:
+    tags:
+      - 'loop-sandbox-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. loop-sandbox-v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: tools/loop-sandbox/package-lock.json
+
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
+      - name: Install, build, test
+        working-directory: tools/loop-sandbox
+        run: |
+          npm ci
+          npm run build
+          npm test
+
+      - name: Skip if version already published
+        id: check
+        working-directory: tools/loop-sandbox
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@cobusgreyling/loop-sandbox@${VERSION}" version 2>/dev/null; then
+            echo "Version ${VERSION} already on npm — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing @cobusgreyling/loop-sandbox@${VERSION}"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        working-directory: tools/loop-sandbox
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-loop-swarm.yml
+++ b/.github/workflows/release-loop-swarm.yml
@@ -1,0 +1,63 @@
+name: Release loop-swarm
+
+on:
+  push:
+    tags:
+      - 'loop-swarm-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. loop-swarm-v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: tools/loop-swarm/package-lock.json
+
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
+      - name: Install, build, test
+        working-directory: tools/loop-swarm
+        run: |
+          npm ci
+          npm run build
+          npm test
+
+      - name: Skip if version already published
+        id: check
+        working-directory: tools/loop-swarm
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@cobusgreyling/loop-swarm@${VERSION}" version 2>/dev/null; then
+            echo "Version ${VERSION} already on npm — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing @cobusgreyling/loop-swarm@${VERSION}"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        working-directory: tools/loop-swarm
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASE_NOTES_DRAFT.md
+++ b/RELEASE_NOTES_DRAFT.md
@@ -1,96 +1,114 @@
-# Release notes draft — since Discussion #294
+# Release notes draft — week of 2026-07-29 (updated 2026-07-29)
 
 **Status:** Draft for human review ([#332](https://github.com/cobusgreyling/loop-engineering/issues/332)). Edit before publishing a discussion post or tagging packages.
 
-**Last published:** [Discussion #294](https://github.com/cobusgreyling/loop-engineering/discussions/294) (2026-07-16) — `loop-context` 1.2.0, `loop-worktree` 1.1.0.
+**Last published discussion:** [Discussion #294](https://github.com/cobusgreyling/loop-engineering/discussions/294) (2026-07-16) — `loop-context` 1.2.0, `loop-worktree` 1.1.0.
 
-**Window:** 2026-07-16 → 2026-07-22
+**Window:** 2026-07-16 → 2026-07-29
 
 ---
 
 ## Highlights
 
-### Prompt caching cost model ([#346](https://github.com/cobusgreyling/loop-engineering/pull/346), [#347](https://github.com/cobusgreyling/loop-engineering/pull/347))
+### Prompt caching cost model (published)
 
-- **`loop-cost` 1.2.0** — `--with-caching` scenario + `stable_fraction` on patterns in `registry.yaml` (cache-read discount on stable report/action tokens).
-- **`loop-context` 1.5.0** — `--budget-scenario caching` resolves a cap from the new scenario (shells out with `--with-caching`).
+- **`loop-cost` 1.2.0** (published) — `--with-caching` scenario + `stable_fraction` on patterns ([#346](https://github.com/cobusgreyling/loop-engineering/pull/346), [#347](https://github.com/cobusgreyling/loop-engineering/pull/347)). Thanks [@Tusm11](https://github.com/Tusm11).
+- **`loop-context` 1.5.0** (published) — `--budget-scenario caching` + frustration circuit breaker.
 
-```bash
-npx @cobusgreyling/loop-cost --pattern daily-triage --level L1 --with-caching
-npx @cobusgreyling/loop-context --check --ledger run.json \
-  --budget-from-pattern daily-triage --budget-level L1 --budget-scenario caching
-```
+### Public worktree lock API
 
-Thanks [@Tusm11](https://github.com/Tusm11).
+- **`loop-worktree` 1.3.0** — public `./lock` subpath export for advisory path locking ([#407](https://github.com/cobusgreyling/loop-engineering/pull/407)). Thanks [@shixi-li](https://github.com/shixi-li).
+  - Tag: `loop-worktree-v1.3.0` (ready once this PR is on main)
 
-### Circuit breaker + packages already on npm
+### MiniMax + memory bridge (`loop-init` 1.6.0)
+
+- `--model-provider minimax` for `--with-foundry` implementer stacks, with `--region` / `--model` ([#418](https://github.com/cobusgreyling/loop-engineering/pull/418)). Thanks [@octo-patch](https://github.com/octo-patch).
+- `--with-memory` memory-engineering bridge scaffold ([#359](https://github.com/cobusgreyling/loop-engineering/pull/359)).
+
+### Audit self-heal (`loop-audit` 1.8.0)
+
+- `--auto-fix` self-heal for missing repo structure + memory readiness signals ([#358](https://github.com/cobusgreyling/loop-engineering/pull/358), [#359](https://github.com/cobusgreyling/loop-engineering/pull/359)).
+
+### MCP runtime tools (`loop-mcp-server` 1.2.0)
+
+- `loop_audit_score` + `loop_check_breaker` tools ([#360](https://github.com/cobusgreyling/loop-engineering/pull/360)).
+
+### New packages — first publish
 
 | Package | Version | Notes |
 |---------|---------|--------|
-| `@cobusgreyling/loop-context` | **1.4.0** (live) → **1.5.0** (this batch) | Frustration circuit breaker [#337](https://github.com/cobusgreyling/loop-engineering/pull/337); caching scenario this batch |
-| `@cobusgreyling/loop-cost` | **1.1.0** (live) → **1.2.0** (this batch) | Prompt-caching estimate this batch |
-| `@cobusgreyling/loop-audit` | **1.7.0** | Live |
-| `@cobusgreyling/loop-init` | **1.5.0** | Live |
-| `@cobusgreyling/loop-worktree` | **1.2.0** | Wait queue + deadlock detection [#292](https://github.com/cobusgreyling/loop-engineering/pull/292); published |
-| `@cobusgreyling/loop-gate` | **1.0.0** | First publish from [#291](https://github.com/cobusgreyling/loop-engineering/pull/291); live |
-| `@cobusgreyling/goal-init` | **1.0.0** | First publish |
-| `@cobusgreyling/readiness-core` | **1.0.0** | First publish (build before loop-audit in CI) |
+| `@cobusgreyling/loop-sandbox` | **1.0.0** | Ephemeral worktree isolation + advisory lock ([#370](https://github.com/cobusgreyling/loop-engineering/pull/370), [#399](https://github.com/cobusgreyling/loop-engineering/pull/399)) |
+| `@cobusgreyling/loop-swarm` | **1.0.0** | Multi-agent majority consensus over sandboxes ([#398](https://github.com/cobusgreyling/loop-engineering/pull/398)). Thanks [@THRISHAL12345](https://github.com/THRISHAL12345). |
 
-### Docs appendices (primitives matrix)
+Publish **sandbox before swarm** (swarm depends on `@cobusgreyling/loop-sandbox@^1.0.0`).
 
-| PR | Contributor | Tool |
-|----|-------------|------|
-| [#351](https://github.com/cobusgreyling/loop-engineering/pull/351) | @shixi-li | Continue.dev (closes #117) |
-| [#350](https://github.com/cobusgreyling/loop-engineering/pull/350) | @adity982 | GitHub Copilot (closes #196) |
+### L3 budget negotiator skill
 
-### Other notable merges (window)
+- `budget-negotiator` skill integrated with `loop-budget` + human safety gates ([#400](https://github.com/cobusgreyling/loop-engineering/pull/400)). Thanks [@THRISHAL12345](https://github.com/THRISHAL12345).
 
-- `loop-worktree` npm path + macOS gc fix [#204](https://github.com/cobusgreyling/loop-engineering/pull/204)
-- Star-history docs + chart automation [#193](https://github.com/cobusgreyling/loop-engineering/pull/193), [#205](https://github.com/cobusgreyling/loop-engineering/pull/205), [#192](https://github.com/cobusgreyling/loop-engineering/pull/192)
-- Daily triage CI: build readiness-core before loop-audit [#349](https://github.com/cobusgreyling/loop-engineering/pull/349)
-- Community docs/stories: multi-loop coordination, Opencode constraints, Hermes examples
+### Docs wave (Windsurf + QUICKSTART)
+
+| PR | Contributor | Topic |
+|----|-------------|--------|
+| [#419](https://github.com/cobusgreyling/loop-engineering/pull/419) | @AIMindCrafter | CI Sweeper production story |
+| [#417](https://github.com/cobusgreyling/loop-engineering/pull/417) | @AIMindCrafter | `loop-sandbox` QUICKSTART |
+| [#416](https://github.com/cobusgreyling/loop-engineering/pull/416) | @AIMindCrafter | `loop-action` QUICKSTART |
+| [#413](https://github.com/cobusgreyling/loop-engineering/pull/413)–[#415](https://github.com/cobusgreyling/loop-engineering/pull/415) | @AIMindCrafter | Windsurf CI / Issue / Dependency sweepers |
+| [#409](https://github.com/cobusgreyling/loop-engineering/pull/409) | @k-anushka14 | Merge-gate subsection in QUICKSTART (closes #391) |
+
+### Earlier window (already noted)
+
+- Memory bridge + Cursor examples + CI reliability ([#355](https://github.com/cobusgreyling/loop-engineering/pull/355)–[#362](https://github.com/cobusgreyling/loop-engineering/pull/362))
+- Primitives matrix: Continue.dev, Copilot, Cline, Roo Code
 
 ---
 
-## Try it
+## Package status (as of 2026-07-29)
+
+| Package | On npm (before this batch) | Target | Action |
+|---------|----------------------------|--------|--------|
+| `@cobusgreyling/loop-cost` | **1.2.0** | 1.2.0 | Done |
+| `@cobusgreyling/loop-context` | **1.5.0** | 1.5.0 | Done |
+| `@cobusgreyling/loop-worktree` | **1.2.0** | **1.3.0** | Tag `loop-worktree-v1.3.0` (version already on main) |
+| `@cobusgreyling/loop-init` | **1.5.0** | **1.6.0** | Version bump in this PR → tag `loop-init-v1.6.0` |
+| `@cobusgreyling/loop-audit` | **1.7.0** | **1.8.0** | Version bump in this PR → tag `loop-audit-v1.8.0` |
+| `@cobusgreyling/loop-mcp-server` | **1.1.0** | **1.2.0** | Version bump in this PR → tag `loop-mcp-server-v1.2.0` |
+| `@cobusgreyling/loop-sandbox` | — | **1.0.0** | First publish → tag `loop-sandbox-v1.0.0` |
+| `@cobusgreyling/loop-swarm` | — | **1.0.0** | First publish after sandbox → tag `loop-swarm-v1.0.0` |
+| `@cobusgreyling/loop-gate` | **1.0.0** | 1.0.0 | No change |
+| `@cobusgreyling/loop` | **0.1.2** | 0.1.2 | No change |
+
+### Suggested publish sequence (human gate — tags only)
+
+1. Merge this version / release-workflow PR.
+2. Tag in order:
+   ```bash
+   git tag loop-worktree-v1.3.0 && git push origin loop-worktree-v1.3.0
+   git tag loop-audit-v1.8.0 && git push origin loop-audit-v1.8.0
+   git tag loop-init-v1.6.0 && git push origin loop-init-v1.6.0
+   git tag loop-mcp-server-v1.2.0 && git push origin loop-mcp-server-v1.2.0
+   git tag loop-sandbox-v1.0.0 && git push origin loop-sandbox-v1.0.0
+   # after sandbox is on npm:
+   git tag loop-swarm-v1.0.0 && git push origin loop-swarm-v1.0.0
+   ```
+3. Confirm with `npm view @cobusgreyling/<pkg> version`.
+4. Fold this draft into a GitHub Discussion; close [#332](https://github.com/cobusgreyling/loop-engineering/issues/332).
+
+---
+
+## Try it (after publish)
 
 ```bash
-npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok
-npx @cobusgreyling/loop-audit . --suggest
-npx @cobusgreyling/loop-cost --pattern daily-triage --level L1 --with-caching
-npx @cobusgreyling/loop-worktree list
+npx @cobusgreyling/loop-worktree --help
+npx @cobusgreyling/loop-init . --pattern daily-triage --tool grok --with-foundry --model-provider minimax
+npx @cobusgreyling/loop-audit . --auto-fix
+npx @cobusgreyling/loop-sandbox --help
+npx @cobusgreyling/loop-swarm run --count 3 -- echo "demo"
 ```
-
----
-
-## npm publish checklist (2026-07-22)
-
-| Package | On npm now | This PR / tag | Action |
-|---------|------------|---------------|--------|
-| `@cobusgreyling/loop-cost` | **1.2.0** | `loop-cost-v1.2.0` | **Published** |
-| `@cobusgreyling/loop-context` | **1.5.0** | `loop-context-v1.5.0` | **Published** |
-| `@cobusgreyling/loop-audit` | 1.7.0 | — | No change |
-| `@cobusgreyling/loop-init` | 1.5.0 | — | No change |
-| `@cobusgreyling/loop-worktree` | 1.2.0 | `loop-worktree-v1.3.0` | Publish 1.3.0 after merge (public `./lock` subpath) |
-| `@cobusgreyling/loop-gate` | 1.0.0 | — | Already published |
-| `@cobusgreyling/goal-init` | 1.0.0 | — | Already published |
-| `@cobusgreyling/readiness-core` | 1.0.0 | — | Already published |
-| `@cobusgreyling/loop-mcp-server` | 1.1.0* | — | No change (*confirm if needed) |
-| `@cobusgreyling/loop-sync` | 1.0.0* | — | No change |
-
-\* Verify with `npm view @cobusgreyling/<pkg> version` before any announce.
-
-### Suggested publish steps
-
-1. ~~Merge version bump PR #352~~ done.
-2. ~~Tag `loop-cost-v1.2.0` + `loop-context-v1.5.0`~~ done; release workflows green.
-3. ~~`npm view` → 1.2.0 / 1.5.0~~ confirmed.
-4. Human: fold this draft into discussion/announce for [#332](https://github.com/cobusgreyling/loop-engineering/issues/332) when ready.
-5. Superseded contributor draft [#348](https://github.com/cobusgreyling/loop-engineering/pull/348) (closed).
 
 ---
 
 ## Housekeeping
 
-- PR triage 2026-07-22: merged #351/#350; closed #344 superseded; held then superseded #348.
-- Feature PRs must include `package.json` bumps + this checklist row in the same change (lesson from #346/#347 gap).
+- PR triage 2026-07-29: merged docs wave + #398/#400/#407/#418; #409 additive rework; #365 release draft refresh superseded by this file.
+- Feature PRs should include `package.json` bumps in the same change (lesson from unpublished features sitting on main at old versions).

--- a/changelog-drafter-state.md
+++ b/changelog-drafter-state.md
@@ -1,0 +1,27 @@
+# Changelog Drafter State
+
+Last run: 2026-07-29T14:55:00Z (manual release prep for #332)
+Last published discussion: #294 (2026-07-16)
+Scan window: 2026-07-16 → 2026-07-29 (main)
+
+## Pending draft
+
+- File: `RELEASE_NOTES_DRAFT.md`
+- Sources: merged PRs through #419; bot star-history / daily-triage noise excluded
+- Breaking changes: 0 known
+- Security items: 0
+- Status: **pending human review**
+
+## Publish gate
+
+- Source verification: pending human
+- Attribution review: pending human
+- Version bumps in `chore/publish-queue-2026-07-29`: loop-audit 1.8.0, loop-init 1.6.0, loop-mcp-server 1.2.0; worktree 1.3.0 already on main; sandbox/swarm 1.0.0 first publish + release workflows
+- Tag / GitHub Release / Discussions: denied to automation — human only
+
+## Next actions (human)
+
+1. Review `RELEASE_NOTES_DRAFT.md`
+2. Merge version-bump / release-workflow PR
+3. Tag + publish in the order listed in the draft
+4. Post discussion / close #332

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -13,6 +13,8 @@ This repo ships public npm packages from `tools/`. **Front door for users:** `@c
 | `@cobusgreyling/loop-context` | `tools/loop-context` | `loop-context-v*` |
 | `@cobusgreyling/loop-mcp-server` | `tools/mcp-server` | `loop-mcp-server-v*` |
 | `@cobusgreyling/loop-worktree` | `tools/loop-worktree` | `loop-worktree-v*` |
+| `@cobusgreyling/loop-sandbox` | `tools/loop-sandbox` | `loop-sandbox-v*` |
+| `@cobusgreyling/loop-swarm` | `tools/loop-swarm` | `loop-swarm-v*` |
 | `@cobusgreyling/loop-gate` | `tools/loop-gate` | `loop-gate-v*` |
 | `@cobusgreyling/goal-audit` | `tools/goal-audit` | `goal-audit-v*` |
 | `@cobusgreyling/goal-init` | `tools/goal-init` | `goal-init-v*` |
@@ -32,6 +34,8 @@ Link npm to GitHub, then for **each package** on [npmjs.com](https://www.npmjs.c
 | `@cobusgreyling/loop-context` | `cobusgreyling/loop-engineering` | `release-loop-context.yml` |
 | `@cobusgreyling/loop-mcp-server` | `cobusgreyling/loop-engineering` | `release-loop-mcp-server.yml` |
 | `@cobusgreyling/loop-worktree` | `cobusgreyling/loop-engineering` | `release-loop-worktree.yml` |
+| `@cobusgreyling/loop-sandbox` | `cobusgreyling/loop-engineering` | `release-loop-sandbox.yml` |
+| `@cobusgreyling/loop-swarm` | `cobusgreyling/loop-engineering` | `release-loop-swarm.yml` |
 | `@cobusgreyling/loop-gate` | `cobusgreyling/loop-engineering` | `release-loop-gate.yml` |
 | `@cobusgreyling/goal-audit` | `cobusgreyling/loop-engineering` | `release-goal-audit.yml` |
 | `@cobusgreyling/goal-init` | `cobusgreyling/loop-engineering` | `release-goal-init.yml` |

--- a/tools/loop-audit/CHANGELOG.md
+++ b/tools/loop-audit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@cobusgreyling/loop-audit` are documented here.
 
+## [1.8.0] - 2026-07-29
+
+### Added
+- `--auto-fix` self-heal for missing repository structure (STATE, LOOP, budgets, gate.yaml, etc.)
+- Memory-engineering readiness signals and `--with-memory` recommendations
+
 ## [1.7.0] - 2026-07-20
 
 ### Added

--- a/tools/loop-audit/package-lock.json
+++ b/tools/loop-audit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cobusgreyling/loop-audit",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cobusgreyling/loop-audit",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@cobusgreyling/readiness-core": "file:../readiness-core"

--- a/tools/loop-audit/package.json
+++ b/tools/loop-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobusgreyling/loop-audit",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Loop engineering readiness auditor. Compute Loop Readiness Score (L0-L3), detect activity + harness runtime, and get actionable suggestions. npx @cobusgreyling/loop-audit . --suggest",
   "type": "module",
   "bin": {

--- a/tools/loop-init/CHANGELOG.md
+++ b/tools/loop-init/CHANGELOG.md
@@ -4,12 +4,15 @@ All notable changes to `@cobusgreyling/loop-init` are documented here.
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-29
+
 ### Added
 - `--model-provider minimax` for `--with-foundry` implementer stacks — emits a `model/minimax` provider primitive instead of the default interface primitive
   - Global (`global_en`) and China (`cn_zh`) endpoint configuration in every generated stack
   - `MiniMax-M3` (default) and `MiniMax-M2.7` model options with context window, input modalities, thinking modes, and pricing
 - `--region` (`global_en`, `cn_zh`) and `--model` (`MiniMax-M3`, `MiniMax-M2.7`) flags to select the active MiniMax region and model
 - Help text and examples for the new flags
+- `--with-memory` memory-engineering bridge scaffold (tiers + budget signals)
 
 ## [1.5.0] - 2026-07-20
 

--- a/tools/loop-init/package-lock.json
+++ b/tools/loop-init/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@cobusgreyling/loop-init",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cobusgreyling/loop-init",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@cobusgreyling/loop-audit": "^1.7.0"
+        "@cobusgreyling/loop-audit": "^1.8.0"
       },
       "bin": {
         "loop-init": "dist/cli.js"

--- a/tools/loop-init/package.json
+++ b/tools/loop-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobusgreyling/loop-init",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Scaffold loop engineering patterns and starters into any project. Optional --with-foundry harness stack. Supports Grok, Claude Code, Codex, Opencode and more. npx @cobusgreyling/loop-init . --pattern daily-triage --tool opencode --with-foundry",
   "type": "module",
   "bin": {
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@cobusgreyling/loop-audit": "^1.7.0"
+    "@cobusgreyling/loop-audit": "^1.8.0"
   },
   "devDependencies": {
     "@types/node": "^26.0.0",

--- a/tools/mcp-server/CHANGELOG.md
+++ b/tools/mcp-server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — @cobusgreyling/loop-mcp-server
 
+## 1.2.0 — 2026-07-29
+
+- `loop_audit_score` tool for runtime Loop Ready scoring
+- `loop_check_breaker` tool for circuit-breaker ledger checks
+
+## 1.1.0
+
+- Prior release (runtime lookup tools)
+
 ## 1.0.0 — 2026-07-06
 
 - Initial npm release

--- a/tools/mcp-server/package-lock.json
+++ b/tools/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cobusgreyling/loop-mcp-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cobusgreyling/loop-mcp-server",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@cobusgreyling/loop-audit": "file:../loop-audit",

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cobusgreyling/loop-mcp-server",
-  "version": "1.1.0",
-  "description": "MCP server for loop-engineering — exposes patterns, skills, state, and audit tools as runtime-queryable resources for AI agents",
+  "version": "1.2.0",
+  "description": "MCP server for loop-engineering \u2014 exposes patterns, skills, state, and audit tools as runtime-queryable resources for AI agents",
   "type": "module",
   "bin": {
     "loop-mcp-server": "dist/index.js"


### PR DESCRIPTION
## Summary

Closes the **publish queue** attention items from triage (2026-07-29) and refreshes release prep for #332.

### Version bumps
| Package | From | To | Why |
|---------|------|-----|-----|
| `loop-audit` | 1.7.0 | **1.8.0** | `--auto-fix`, memory signals (#358/#359) |
| `loop-init` | 1.5.0 | **1.6.0** | MiniMax provider (#418) + `--with-memory` (#359) |
| `loop-mcp-server` | 1.1.0 | **1.2.0** | `loop_audit_score`, `loop_check_breaker` (#360) |
| `loop-worktree` | — | **1.3.0** | Already on main (#407) — **tag only** |
| `loop-sandbox` | — | **1.0.0** | First publish + release workflow |
| `loop-swarm` | — | **1.0.0** | First publish + release workflow |

### Also
- Refresh `RELEASE_NOTES_DRAFT.md` + `changelog-drafter-state.md` for window 2026-07-16 → 2026-07-29 (supersedes stale #365 draft content)
- Document sandbox/swarm in `docs/RELEASE.md`

### Not in this PR (human gate)
- No tags / npm publishes — after merge, tag in the order listed in `RELEASE_NOTES_DRAFT.md`
- No Discussion post / close of #332

### Suggested tags after merge
```bash
git tag loop-worktree-v1.3.0 && git push origin loop-worktree-v1.3.0
git tag loop-audit-v1.8.0 && git push origin loop-audit-v1.8.0
git tag loop-init-v1.6.0 && git push origin loop-init-v1.6.0
git tag loop-mcp-server-v1.2.0 && git push origin loop-mcp-server-v1.2.0
git tag loop-sandbox-v1.0.0 && git push origin loop-sandbox-v1.0.0
# after sandbox is on npm:
git tag loop-swarm-v1.0.0 && git push origin loop-swarm-v1.0.0
```

## Test plan
- [ ] CI green on this PR
- [ ] After merge + tags: `npm view @cobusgreyling/<pkg> version` matches table
- [ ] Human review of `RELEASE_NOTES_DRAFT.md` before Discussion

Related: #332, supersedes draft PR #365 content