### PR TITLE
fix(release): OIDC trusted publish + resilient pack test

### DIFF
--- a/.github/workflows/release-goal-audit.yml
+++ b/.github/workflows/release-goal-audit.yml
@@ -46,4 +46,5 @@ jobs:
           "
           npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-goal-init.yml
+++ b/.github/workflows/release-goal-init.yml
@@ -53,11 +53,13 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Publish to npm
         if: steps.check.outputs.skip != 'true'
         working-directory: tools/goal-init
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-audit.yml
+++ b/.github/workflows/release-loop-audit.yml
@@ -56,4 +56,5 @@ jobs:
           "
           npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-context.yml
+++ b/.github/workflows/release-loop-context.yml
@@ -48,4 +48,5 @@ jobs:
         working-directory: tools/loop-context
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-cost.yml
+++ b/.github/workflows/release-loop-cost.yml
@@ -44,4 +44,5 @@ jobs:
         working-directory: tools/loop-cost
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-gate.yml
+++ b/.github/workflows/release-loop-gate.yml
@@ -53,11 +53,13 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Publish to npm
         if: steps.check.outputs.skip != 'true'
         working-directory: tools/loop-gate
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-init.yml
+++ b/.github/workflows/release-loop-init.yml
@@ -53,4 +53,5 @@ jobs:
           # package.json keeps registry range (^1.x) for the published tarball
           npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-mcp-server.yml
+++ b/.github/workflows/release-loop-mcp-server.yml
@@ -60,11 +60,13 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Publish to npm
         if: steps.check.outputs.skip != 'true'
         working-directory: tools/mcp-server
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-sandbox.yml
+++ b/.github/workflows/release-loop-sandbox.yml
@@ -53,11 +53,13 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Publish to npm
         if: steps.check.outputs.skip != 'true'
         working-directory: tools/loop-sandbox
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-swarm.yml
+++ b/.github/workflows/release-loop-swarm.yml
@@ -53,11 +53,13 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Publish to npm
         if: steps.check.outputs.skip != 'true'
         working-directory: tools/loop-swarm
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-sync.yml
+++ b/.github/workflows/release-loop-sync.yml
@@ -44,4 +44,5 @@ jobs:
         working-directory: tools/loop-sync
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-worktree.yml
+++ b/.github/workflows/release-loop-worktree.yml
@@ -53,11 +53,13 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Publish to npm
         if: steps.check.outputs.skip != 'true'
         working-directory: tools/loop-worktree
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop.yml
+++ b/.github/workflows/release-loop.yml
@@ -51,4 +51,5 @@ jobs:
         working-directory: tools/loop
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-readiness-core.yml
+++ b/.github/workflows/release-readiness-core.yml
@@ -46,4 +46,5 @@ jobs:
         working-directory: tools/readiness-core
         run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NPM_CONFIG_PROVENANCE: "true"

--- a/tools/loop-worktree/test/package-exports.test.mjs
+++ b/tools/loop-worktree/test/package-exports.test.mjs
@@ -52,10 +52,23 @@ test('packed package exposes the public lock subpath and keeps legacy deep impor
   const parsed = JSON.parse(stdout.slice(jsonStart));
   const packed = Array.isArray(parsed) ? parsed : [parsed];
   assert.equal(packed.length, 1);
-  assert.ok(
-    packed[0].files.some((file) => file.path === 'dist/lock.d.ts'),
-    'packed lock subpath should include its declarations',
-  );
+  const tarball = path.join(temp, packed[0].filename);
+  assert.ok(packed[0].filename, 'npm pack should report a tarball filename');
+  // Prefer files[] when present; otherwise inspect the tarball (npm@latest may omit files).
+  if (Array.isArray(packed[0].files)) {
+    assert.ok(
+      packed[0].files.some((file) => file.path === 'dist/lock.d.ts'),
+      'packed lock subpath should include its declarations',
+    );
+  } else {
+    const { stdout: tarList } = await run('tar', ['-tzf', tarball], {
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    assert.ok(
+      tarList.split('\n').some((line) => line.endsWith('dist/lock.d.ts') || line.endsWith('/dist/lock.d.ts') || line === 'package/dist/lock.d.ts'),
+      `tarball missing dist/lock.d.ts; listing:\n${tarList}`,
+    );
+  }
 
   const consumer = path.join(temp, 'consumer');
   await mkdir(consumer);


### PR DESCRIPTION
## Summary
Second publish attempt still failed with **npm PUT E404** on every package. Provenance signed (OIDC works) but publish used `secrets.NPM_TOKEN`, which overrides OIDC and appears invalid/expired.

Also `loop-worktree` pack test still failed when `npm pack --json` omitted `files[]`.

### Changes
- Remove `NODE_AUTH_TOKEN` from all `release-*.yml` publish/check steps
- Pack test falls back to `tar -tzf` when `files[]` is missing

### Note
New packages (`loop-sandbox`, `loop-swarm`) need **Trusted Publisher** configured on npmjs.com for OIDC publish to work. Existing packages should already have them if prior OIDC publishes succeeded.