### PR TITLE
docs: add MiniMax foundry flags to QUICKSTART (#425)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -97,6 +97,20 @@ npx @cobusgreyling/harness-foundry validate
 npx @cobusgreyling/harness-foundry run --goal "Verify harness wiring"
 ```
 
+To configure provider-specific stacks like **MiniMax** during scaffolding:
+
+```bash
+npx @cobusgreyling/loop init . --pattern daily-triage --tool grok \
+  --with-foundry --model-provider minimax --region global_en --model MiniMax-M3
+```
+
+> **MiniMax Foundry flags:**
+> - `--model-provider minimax`
+> - `--region`: `global_en` (default) | `cn_zh`
+> - `--model`: e.g. `MiniMax-M3`
+>
+> See [harness-foundry](https://github.com/cobusgreyling/harness-foundry) for full provider and stack runtime documentation.
+
 ### Catch drift before you schedule (`loop sync`)
 
 `loop audit` scores readiness; `loop sync` checks that your `STATE.md` and `LOOP.md` still agree. When they drift — you edit `LOOP.md` to add a loop but never wire it into `STATE.md`, or a starter update leaves one file behind — a scheduled loop can run against stale instructions. `loop doctor` runs this for you.

--- a/docs/cli-front-door.md
+++ b/docs/cli-front-door.md
@@ -33,6 +33,8 @@ npx @cobusgreyling/loop doctor .
 | `loop doctor .` | **new** (audit + sync + files) |
 | `loop status .` | **new** (run-log dashboard) |
 
+`loop init` with `--with-foundry` supports custom provider flags such as `--model-provider minimax --region (global_en|cn_zh) --model MiniMax-M3`. See [QUICKSTART](./QUICKSTART.md#4-audit-readiness-30-seconds) for examples.
+
 ## Doctor exit codes
 
 | Code | Meaning | CI use |


### PR DESCRIPTION
## Summary
<!-- One sentence what this does and why -->

## Changes
- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example improvement
- [ ] Tool change (loop-audit)
- [ ] Story (includes real failure or surprise + lesson)

## Checklist (from CONTRIBUTING)
- [ ] All required sections present for patterns
- [ ] Links work from README, patterns/README, starters/README, docs/index
- [ ] No secrets, tokens, internal company URLs
- [ ] `STATE.md*` examples use `.example` suffix
- [ ] Safety-related content references `docs/safety.md`
- [ ] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood
- [ ] `loop-audit` passes on affected starters or this repo
- [ ] Manual review of generated state / skill output

## Screenshots / Examples (if UI or command output)
<!-- Paste relevant output or link to rendered docs -->

---

*This template enforces the high bar this reference is known for.*
