### PR TITLE
docs: document public loop-worktree lock import in QUICKSTART (#426)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -283,6 +283,20 @@ npx @cobusgreyling/loop-worktree cleanup --older-than 24h
 npx @cobusgreyling/loop-worktree list
 ```
 
+To prevent multi-loop collisions on shared paths across concurrent runs, use advisory path locks via CLI or public JS import:
+
+```bash
+# CLI advisory lock (skips or queues if another owner holds an overlapping path)
+npx @cobusgreyling/loop-worktree lock --paths package.json,package-lock.json --owner dependency-sweeper --ttl 6h
+npx @cobusgreyling/loop-worktree unlock --owner dependency-sweeper
+```
+
+Programmatic loops can import lock primitives directly from `@cobusgreyling/loop-worktree/lock` without deep-importing internal files under `dist/`:
+
+```js
+import { lockPaths, unlockPaths, LOCKS_DIR } from '@cobusgreyling/loop-worktree/lock';
+```
+
 Pair with the [circuit breaker](#circuit-breaker-for-l2-loops-optional) above: when `loop-context --check` exits `2`, mark the worktree `escalated` before handing off to a human. The two tools stay independent — see [tools/loop-worktree/README.md](../tools/loop-worktree/README.md).
 
 ### Ephemeral worktree isolation (`loop-sandbox`)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -294,7 +294,10 @@ npx @cobusgreyling/loop-worktree unlock --owner dependency-sweeper
 Programmatic loops can import lock primitives directly from `@cobusgreyling/loop-worktree/lock` without deep-importing internal files under `dist/`:
 
 ```js
-import { lockPaths, unlockPaths, LOCKS_DIR } from '@cobusgreyling/loop-worktree/lock';
+import { lockPaths, unlockOwner, LOCKS_DIR } from '@cobusgreyling/loop-worktree/lock';
+
+await lockPaths({ root, owner, paths, ttl: '6h' });
+await unlockOwner(root, owner);
 ```
 
 Pair with the [circuit breaker](#circuit-breaker-for-l2-loops-optional) above: when `loop-context --check` exits `2`, mark the worktree `escalated` before handing off to a human. The two tools stay independent — see [tools/loop-worktree/README.md](../tools/loop-worktree/README.md).

--- a/tools/loop-worktree/README.md
+++ b/tools/loop-worktree/README.md
@@ -30,7 +30,7 @@ import { lockPaths, unlockOwner } from '@cobusgreyling/loop-worktree/lock';
 ```
 
 The `lock` subpath is the stable programmatic entry point for tools that need
-advisory path locking without importing private files under `dist/`.
+advisory path locking without importing private files under `dist/`. See [Quickstart](../../docs/QUICKSTART.md#l2-isolated-fix-attempts-loop-worktree) for CLI and JS usage.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
<!-- One sentence what this does and why -->

## Changes
- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example improvement
- [ ] Tool change (loop-audit)
- [ ] Story (includes real failure or surprise + lesson)

## Checklist (from CONTRIBUTING)
- [ ] All required sections present for patterns
- [ ] Links work from README, patterns/README, starters/README, docs/index
- [ ] No secrets, tokens, internal company URLs
- [ ] `STATE.md*` examples use `.example` suffix
- [ ] Safety-related content references `docs/safety.md`
- [ ] Ran `node tools/loop-audit/dist/cli.js .` (or on the starter) and addressed findings

## Testing / Dogfood
- [ ] `loop-audit` passes on affected starters or this repo
- [ ] Manual review of generated state / skill output

## Screenshots / Examples (if UI or command output)
<!-- Paste relevant output or link to rendered docs -->

---

*This template enforces the high bar this reference is known for.*
