### PR TITLE
fix(mcp-server): loop_estimate_cost honors early_exit_required

### DIFF
--- a/tools/mcp-server/dist/index.js
+++ b/tools/mcp-server/dist/index.js
@@ -7,6 +7,7 @@ import { readFile } from 'node:fs/promises';
 import { loadGateConfig, checkGate } from '@cobusgreyling/loop-gate';
 import { auditProject } from '@cobusgreyling/loop-audit/dist/auditor.js';
 import { checkCircuitBreaker, DEFAULT_BREAKER } from '@cobusgreyling/loop-context';
+import { estimateCost } from '@cobusgreyling/loop-cost/dist/estimator.js';
 import { resolveProjectRoot, loadRegistry, loadPatternDoc, listSkills, loadSkill, loadState, listStateFiles, loadLoopConfig, loadBudget, loadRunLog, loadSafetyDoc, listPatternDocs, loadGatePolicy, } from './resolver.js';
 const server = new McpServer({
     name: 'loop-engineering',
@@ -279,48 +280,30 @@ server.tool('loop_estimate_cost', 'Estimate daily token cost for a pattern at a 
                 }],
         };
     }
-    const effectiveCadence = cadence ?? pattern.cadence;
-    const parts = effectiveCadence.split('-').map(p => p.trim());
-    let runsPerDay;
+    let result;
     try {
-        const intervals = parts.map(p => {
-            const m = p.match(/^(\d+)([mhd])$/);
-            if (!m)
-                throw new Error(`Invalid interval: ${p}`);
-            const ms = { m: 60_000, h: 3_600_000, d: 86_400_000 };
-            return Number(m[1]) * ms[m[2]];
-        });
-        runsPerDay = Math.floor(86_400_000 / Math.min(...intervals));
+        result = estimateCost({ pattern, level, cadence });
     }
     catch {
-        return { content: [{ type: 'text', text: `Invalid cadence: ${effectiveCadence}` }] };
+        return { content: [{ type: 'text', text: `Invalid cadence: ${cadence ?? pattern.cadence}` }] };
     }
-    const { cost } = pattern;
-    const mix = level === 'L1'
-        ? { noop: 0.6, report: 0.4, action: 0 }
-        : level === 'L2'
-            ? { noop: 0.5, report: 0.3, action: 0.2 }
-            : { noop: 0.4, report: 0.35, action: 0.25 };
-    const realisticPerRun = cost.tokens_noop * mix.noop
-        + cost.tokens_report * mix.report
-        + cost.tokens_action * mix.action;
-    const realisticPerDay = Math.round(realisticPerRun * runsPerDay);
     const fmt = (n) => n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1_000 ? `${Math.round(n / 1_000)}k` : String(n);
+    const { scenarios, suggestedDailyCap } = result;
     const lines = [
         `## Cost Estimate: ${pattern.name}`,
-        `- **Cadence:** ${effectiveCadence} (${runsPerDay} runs/day)`,
+        `- **Cadence:** ${result.cadence} (${result.runsPerDay} runs/day)`,
         `- **Level:** ${level}`,
-        `- **Daily cap:** ${fmt(cost.suggested_daily_cap)}`,
+        `- **Daily cap:** ${fmt(suggestedDailyCap)}`,
         '',
         '| Scenario | Per Run | Per Day |',
         '|----------|---------|---------|',
-        `| No-op | ${fmt(cost.tokens_noop)} | ${fmt(cost.tokens_noop * runsPerDay)} |`,
-        `| Report | ${fmt(cost.tokens_report)} | ${fmt(cost.tokens_report * runsPerDay)} |`,
-        `| Action | ${fmt(cost.tokens_action)} | ${fmt(cost.tokens_action * runsPerDay)} |`,
-        `| **Realistic** | **${fmt(Math.round(realisticPerRun))}** | **${fmt(realisticPerDay)}** |`,
+        `| No-op | ${fmt(scenarios.noop.tokensPerRun)} | ${fmt(scenarios.noop.tokensPerDay)} |`,
+        `| Report | ${fmt(scenarios.report.tokensPerRun)} | ${fmt(scenarios.report.tokensPerDay)} |`,
+        `| Action | ${fmt(scenarios.action.tokensPerRun)} | ${fmt(scenarios.action.tokensPerDay)} |`,
+        `| **Realistic** | **${fmt(scenarios.realistic.tokensPerRun)}** | **${fmt(scenarios.realistic.tokensPerDay)}** |`,
     ];
-    if (realisticPerDay > cost.suggested_daily_cap) {
-        lines.push('', `> Warning: realistic estimate exceeds daily cap of ${fmt(cost.suggested_daily_cap)}`);
+    if (scenarios.realistic.tokensPerDay > suggestedDailyCap) {
+        lines.push('', `> Warning: realistic estimate exceeds daily cap of ${fmt(suggestedDailyCap)}`);
     }
     return { content: [{ type: 'text', text: lines.join('\n') }] };
 });

--- a/tools/mcp-server/package-lock.json
+++ b/tools/mcp-server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@cobusgreyling/loop-audit": "file:../loop-audit",
         "@cobusgreyling/loop-context": "file:../loop-context",
+        "@cobusgreyling/loop-cost": "file:../loop-cost",
         "@cobusgreyling/loop-gate": "file:../loop-gate",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "minimatch": "^10.2.5",
@@ -30,7 +31,7 @@
     },
     "../loop-audit": {
       "name": "@cobusgreyling/loop-audit",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@cobusgreyling/readiness-core": "file:../readiness-core"
@@ -55,6 +56,24 @@
       },
       "bin": {
         "loop-context": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../loop-cost": {
+      "name": "@cobusgreyling/loop-cost",
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      },
+      "bin": {
+        "loop-cost": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -89,6 +108,10 @@
     },
     "node_modules/@cobusgreyling/loop-context": {
       "resolved": "../loop-context",
+      "link": true
+    },
+    "node_modules/@cobusgreyling/loop-cost": {
+      "resolved": "../loop-cost",
       "link": true
     },
     "node_modules/@cobusgreyling/loop-gate": {

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@cobusgreyling/loop-audit": "file:../loop-audit",
     "@cobusgreyling/loop-context": "file:../loop-context",
+    "@cobusgreyling/loop-cost": "file:../loop-cost",
     "@cobusgreyling/loop-gate": "file:../loop-gate",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "minimatch": "^10.2.5",

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -8,6 +8,7 @@ import { readFile } from 'node:fs/promises';
 import { loadGateConfig, checkGate } from '@cobusgreyling/loop-gate';
 import { auditProject } from '@cobusgreyling/loop-audit/dist/auditor.js';
 import { checkCircuitBreaker, DEFAULT_BREAKER, Ledger } from '@cobusgreyling/loop-context';
+import { estimateCost } from '@cobusgreyling/loop-cost/dist/estimator.js';
 import {
   resolveProjectRoot,
   loadRegistry,
@@ -398,51 +399,32 @@ server.tool(
       };
     }
 
-    const effectiveCadence = cadence ?? pattern.cadence;
-    const parts = effectiveCadence.split('-').map(p => p.trim());
-    let runsPerDay: number;
+    let result;
     try {
-      const intervals = parts.map(p => {
-        const m = p.match(/^(\d+)([mhd])$/);
-        if (!m) throw new Error(`Invalid interval: ${p}`);
-        const ms: Record<string, number> = { m: 60_000, h: 3_600_000, d: 86_400_000 };
-        return Number(m[1]) * ms[m[2]];
-      });
-      runsPerDay = Math.floor(86_400_000 / Math.min(...intervals));
+      result = estimateCost({ pattern, level, cadence });
     } catch {
-      return { content: [{ type: 'text' as const, text: `Invalid cadence: ${effectiveCadence}` }] };
+      return { content: [{ type: 'text' as const, text: `Invalid cadence: ${cadence ?? pattern.cadence}` }] };
     }
 
-    const { cost } = pattern;
-    const mix = level === 'L1'
-      ? { noop: 0.6, report: 0.4, action: 0 }
-      : level === 'L2'
-        ? { noop: 0.5, report: 0.3, action: 0.2 }
-        : { noop: 0.4, report: 0.35, action: 0.25 };
-
-    const realisticPerRun = cost.tokens_noop * mix.noop
-      + cost.tokens_report * mix.report
-      + cost.tokens_action * mix.action;
-    const realisticPerDay = Math.round(realisticPerRun * runsPerDay);
-
     const fmt = (n: number) => n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1_000 ? `${Math.round(n / 1_000)}k` : String(n);
+    const { scenarios, suggestedDailyCap } = result;
 
     const lines = [
       `## Cost Estimate: ${pattern.name}`,
-      `- **Cadence:** ${effectiveCadence} (${runsPerDay} runs/day)`,
+      `- **Cadence:** ${result.cadence} (${result.runsPerDay} runs/day)`,
       `- **Level:** ${level}`,
-      `- **Daily cap:** ${fmt(cost.suggested_daily_cap)}`,
+      `- **Daily cap:** ${fmt(suggestedDailyCap)}`,
       '',
       '| Scenario | Per Run | Per Day |',
       '|----------|---------|---------|',
-      `| No-op | ${fmt(cost.tokens_noop)} | ${fmt(cost.tokens_noop * runsPerDay)} |`,
-      `| Report | ${fmt(cost.tokens_report)} | ${fmt(cost.tokens_report * runsPerDay)} |`,
-      `| Action | ${fmt(cost.tokens_action)} | ${fmt(cost.tokens_action * runsPerDay)} |`,
-      `| **Realistic** | **${fmt(Math.round(realisticPerRun))}** | **${fmt(realisticPerDay)}** |`,
+      `| No-op | ${fmt(scenarios.noop.tokensPerRun)} | ${fmt(scenarios.noop.tokensPerDay)} |`,
+      `| Report | ${fmt(scenarios.report.tokensPerRun)} | ${fmt(scenarios.report.tokensPerDay)} |`,
+      `| Action | ${fmt(scenarios.action.tokensPerRun)} | ${fmt(scenarios.action.tokensPerDay)} |`,
+      `| **Realistic** | **${fmt(scenarios.realistic.tokensPerRun)}** | **${fmt(scenarios.realistic.tokensPerDay)}** |`,
     ];
 
-    if (realisticPerDay > cost.suggested_daily_cap) {
-      lines.push('', `> Warning: realistic estimate exceeds daily cap of ${fmt(cost.suggested_daily_cap)}`);
+    if (scenarios.realistic.tokensPerDay > suggestedDailyCap) {
+      lines.push('', `> Warning: realistic estimate exceeds daily cap of ${fmt(suggestedDailyCap)}`);
     }
 
     return { content: [{ type: 'text' as const, text: lines.join('\n') }] };

--- a/tools/mcp-server/test/server.test.mjs
+++ b/tools/mcp-server/test/server.test.mjs
@@ -52,6 +52,26 @@ async function setup() {
       tokens_action: 200000
       suggested_daily_cap: 100000
       early_exit_required: false
+  - id: ci-sweeper
+    name: CI Sweeper
+    file: ci-sweeper.md
+    goal: Keep CI green
+    cadence: 1d-2h
+    risk: low
+    tools: [grok, claude-code]
+    skills: [ci-triage]
+    state: STATE.md
+    phases: [report, act-small-wins, escalate]
+    human_gates: [design-decisions]
+    starter: starters/minimal-loop
+    week_one_mode: L1
+    token_cost: low
+    cost:
+      tokens_noop: 5000
+      tokens_report: 50000
+      tokens_action: 200000
+      suggested_daily_cap: 100000
+      early_exit_required: true
 `,
   );
 
@@ -194,7 +214,7 @@ test('loadRegistry parses YAML correctly', async () => {
   try {
     const registry = await loadRegistry(root);
     assert.ok(registry);
-    assert.equal(registry.patterns.length, 1);
+    assert.equal(registry.patterns.length, 2);
     assert.equal(registry.patterns[0].id, 'daily-triage');
     assert.equal(registry.patterns[0].cost.tokens_noop, 5000);
   } finally {
@@ -416,6 +436,25 @@ test('loop_estimate_cost tool computes a cost table', async () => {
     const text = res.get(1).result.content[0].text;
     assert.ok(text.includes('Cost Estimate'));
     assert.ok(text.includes('runs/day'));
+  } finally {
+    await cleanup();
+  }
+});
+
+test('loop_estimate_cost accounts for early_exit_required instead of a flat mix', async () => {
+  const root = await setup();
+  try {
+    const res = await callServer(root, [{
+      id: 1, method: 'tools/call',
+      params: { name: 'loop_estimate_cost', arguments: { patternId: 'ci-sweeper', level: 'L2' } },
+    }]);
+    const text = res.get(1).result.content[0].text;
+    // ci-sweeper has early_exit_required: true and the same token costs as
+    // daily-triage; loop-cost's realisticMix uses {noop:.85,report:.1,action:.05}
+    // for L2 early-exit, giving ~19k tokens/run realistic — not the ~58k a flat
+    // non-early-exit mix ({noop:.5,report:.3,action:.2}) would produce.
+    assert.match(text, /\*\*19k\*\*/);
+    assert.ok(!text.includes('58k'));
   } finally {
     await cleanup();
   }


### PR DESCRIPTION
## Summary

Fixes #434.

`loop_estimate_cost` reimplemented loop-cost's realistic-mix table
by hand instead of importing it, and the reimplementation never read
`pattern.cost.early_exit_required`. For early-exit patterns (e.g.
`ci-sweeper`, `pr-babysitter`) this overestimated the "Realistic"
cost by roughly 3x compared to the actual `@cobusgreyling/loop-cost`
library/CLI the docs point users to.

## Changes
- Tool change (mcp-server)

`mcp-server` already depends on sibling tool packages via
`file:../<tool>` + deep `dist/` imports (see how it already imports
`@cobusgreyling/loop-audit/dist/auditor.js`, `@cobusgreyling/loop-gate`,
`@cobusgreyling/loop-context`). Added `@cobusgreyling/loop-cost` the
same way and call its `estimateCost()` directly instead of hand-
maintaining a duplicate mix table, so the two tools can't drift again.

## Checklist (from CONTRIBUTING)
- [x] Tool change, not a pattern/story — pattern-template checklist n/a
- [x] No secrets, tokens, internal company URLs
- [x] `npm test` passes for `tools/mcp-server` (26/26) and `tools/loop-cost` (12/12)

## Testing / Dogfood
- Added `loop_estimate_cost accounts for early_exit_required instead of
  a flat mix` to `test/server.test.mjs`, using a `ci-sweeper` fixture
  pattern (`early_exit_required: true`) with the same token costs as
  the existing `daily-triage` fixture. Verified this test fails against
  the pre-fix code (asserts `**58k**`, the buggy flat-mix output)
  and passes against the fix (`**19k**`, matching loop-cost's own
  `realisticMix` for L2 early-exit).
- Updated `loadRegistry parses YAML correctly`'s pattern-count
  assertion (1 → 2) for the added fixture pattern.

## Reproduction (before the fix)

For `ci-sweeper` (`early_exit_required: true`) at level L2:
- `loop-cost` (canonical): ~19,250 tokens/run realistic estimate
- `loop_estimate_cost` MCP tool (before this fix): ~57,500 tokens/run