### PR TITLE
fix(loop-sandbox): use loop-worktree's public lock subpath instead of a dist/ deep import

### DIFF
--- a/tools/loop-sandbox/dist/sandbox.js
+++ b/tools/loop-sandbox/dist/sandbox.js
@@ -4,16 +4,7 @@ import { mkdir, writeFile, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { createWorktree, isGitRepo, gc } from '@cobusgreyling/loop-worktree';
-// loop-worktree's package.json has no "exports" map restricting subpaths, so
-// this resolves cleanly; a re-export from the package's main entry was tried
-// first but creates a module-load cycle (lock.js reads MANIFEST_DIR from
-// worktree.js, which would need lock.js's own export to finish first).
-//
-// This reaches into loop-worktree's compiled internals rather than a public
-// subpath export, since none exists yet -- a supported `loop-worktree/lock`
-// entry point would be a better long-term home for this, tracked as a
-// follow-up rather than done here to keep this change scoped to sandbox.ts.
-import { lockPaths, unlockOwner } from '@cobusgreyling/loop-worktree/dist/lock.js';
+import { lockPaths, unlockOwner } from '@cobusgreyling/loop-worktree/lock';
 const runExec = promisify(execFile);
 /** Run a git command in cwd, returning stdout trimmed. Throws on error. */
 async function git(args, cwd) {

--- a/tools/loop-sandbox/package-lock.json
+++ b/tools/loop-sandbox/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cobusgreyling/loop-worktree": "file:../loop-worktree"
+        "@cobusgreyling/loop-worktree": "^1.3.0"
       },
       "bin": {
         "loop-sandbox": "dist/cli.js"
@@ -24,7 +24,7 @@
     },
     "../loop-worktree": {
       "name": "@cobusgreyling/loop-worktree",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "license": "MIT",
       "bin": {
         "loop-worktree": "dist/cli.js"

--- a/tools/loop-sandbox/package.json
+++ b/tools/loop-sandbox/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@cobusgreyling/loop-worktree": "^1.2.0"
+    "@cobusgreyling/loop-worktree": "^1.3.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/tools/loop-sandbox/src/sandbox.ts
+++ b/tools/loop-sandbox/src/sandbox.ts
@@ -4,16 +4,7 @@ import { mkdir, writeFile, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { createWorktree, isGitRepo, gc } from '@cobusgreyling/loop-worktree';
-// loop-worktree's package.json has no "exports" map restricting subpaths, so
-// this resolves cleanly; a re-export from the package's main entry was tried
-// first but creates a module-load cycle (lock.js reads MANIFEST_DIR from
-// worktree.js, which would need lock.js's own export to finish first).
-//
-// This reaches into loop-worktree's compiled internals rather than a public
-// subpath export, since none exists yet -- a supported `loop-worktree/lock`
-// entry point would be a better long-term home for this, tracked as a
-// follow-up rather than done here to keep this change scoped to sandbox.ts.
-import { lockPaths, unlockOwner } from '@cobusgreyling/loop-worktree/dist/lock.js';
+import { lockPaths, unlockOwner } from '@cobusgreyling/loop-worktree/lock';
 
 const runExec = promisify(execFile);
 


### PR DESCRIPTION
## Summary

loop-worktree 1.3.0 (#407) added a supported `@cobusgreyling/loop-worktree/lock`
export (lockPaths, unlockOwner, LOCKS_DIR) specifically so consumers wouldn't
need to reach into `dist/`. loop-sandbox's advisory-lock integration (#399)
predates that export and was importing from
`@cobusgreyling/loop-worktree/dist/lock.js` directly, with a comment flagging
it as a known workaround pending a public entry point.

Switches the import to the supported `@cobusgreyling/loop-worktree/lock`
subpath and bumps the dependency floor to `^1.3.0` (the first version whose
package.json exports map actually defines `./lock` -- an install pinned
below that has no such subpath to resolve).

## Test plan

- Full clean rebuild (`rm -rf node_modules dist && npm install && npm run build`)
  of both `loop-worktree` and `loop-sandbox`.
- `npm test` in `loop-worktree`: 35/35 passing, including the package's own
  `packed package exposes the public lock subpath and keeps legacy deep
  imports` test.
- `npm test` in `loop-sandbox`: 10/10 passing, unchanged behavior since this
  is an import-path swap with no logic changes.