### PR TITLE
fix(docs): stop Live Telemetry charts from growing endlessly + pin CDN script versions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@ title: Loop Engineering — Showcase
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/showcase.css">
   <link rel="icon" href="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/loop-engineering-logo.svg">
   <script type="module">
-    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.esm.min.mjs";
     mermaid.initialize({
       startOnLoad: true,
       theme: "dark",
@@ -36,7 +36,7 @@ title: Loop Engineering — Showcase
       },
     });
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"></script>
 </head>
 <body>
 
@@ -1073,11 +1073,8 @@ async function renderTelemetry() {
     const labels = data.map(d => new Date(d.run_id).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }));
     
     const scores = data.map(d => d.readiness_score || 0);
-    const tokens = data.map((d, i) => {
-      let sum = 0;
-      for (let j = 0; j <= i; j++) sum += (data[j].tokens_estimate || 0);
-      return sum;
-    });
+    let tokenRunningTotal = 0;
+    const tokens = data.map(d => (tokenRunningTotal += (d.tokens_estimate || 0)));
     const automatedRuns = data.map(d => d.outcome === 'escalated' ? 0 : 1);
     const escalatedRuns = data.map(d => d.outcome === 'escalated' ? 1 : 0);
     

--- a/docs/index.html
+++ b/docs/index.html
@@ -626,15 +626,21 @@ npx @cobusgreyling/loop-audit . --suggest
   <div class="telemetry-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 24px; margin-top: 32px; margin-bottom: 40px;">
     <div class="card" style="padding: 20px; background: var(--bg-card); border: 1px solid var(--border-subtle); border-radius: 8px;">
       <h3 style="font-size: 1rem; margin-bottom: 16px; color: var(--text-muted);">Loop Readiness Score</h3>
-      <canvas id="scoreChart" height="200"></canvas>
+      <div style="position: relative; height: 240px;">
+        <canvas id="scoreChart"></canvas>
+      </div>
     </div>
     <div class="card" style="padding: 20px; background: var(--bg-card); border: 1px solid var(--border-subtle); border-radius: 8px;">
       <h3 style="font-size: 1rem; margin-bottom: 16px; color: var(--text-muted);">Cumulative Tokens (Estimate)</h3>
-      <canvas id="tokenChart" height="200"></canvas>
+      <div style="position: relative; height: 240px;">
+        <canvas id="tokenChart"></canvas>
+      </div>
     </div>
     <div class="card" style="padding: 20px; background: var(--bg-card); border: 1px solid var(--border-subtle); border-radius: 8px;">
       <h3 style="font-size: 1rem; margin-bottom: 16px; color: var(--text-muted);">Automated vs Escalated Runs</h3>
-      <canvas id="escalationChart" height="200"></canvas>
+      <div style="position: relative; height: 240px;">
+        <canvas id="escalationChart"></canvas>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

The three charts in the Dogfooding / Live Telemetry section
(https://cobusgreyling.github.io/loop-engineering/#telemetry) grew taller
forever, making the page feel like it never finished loading. Root cause:
each canvas sat directly inside a `.card` div with no explicit height.
Chart.js is configured with `responsive: true` + `maintainAspectRatio:
false`, which resizes the canvas to fill its parent -- but since the
container's own height was determined by the canvas inside it, every
resize grew the container, which re-triggered Chart.js's ResizeObserver,
which grew the canvas again. Unbounded feedback loop.

Fixed by wrapping each canvas in a `position: relative; height: 240px`
container, so the container's size no longer depends on the canvas it
holds.

Also, while investigating:
- Both third-party scripts on the page were unpinned (`mermaid@11` floats
  across every 11.x release, and the Chart.js `<script>` tag had no
  version at all) -- any upstream release of either library can silently
  change or break the live page with zero corresponding commit here.
  Pinned both to the versions currently being served (mermaid 11.16.0,
  Chart.js 4.5.1).
- `renderTelemetry()`'s cumulative-tokens calculation recomputed the full
  prefix sum from scratch for every point (O(n^2) over loop-run-log.md's
  entries) instead of carrying a running total. loop-run-log.md is
  appended to daily with nothing pruning it, so this cost compounds
  indefinitely. Replaced with an O(n) running total.

## Test plan

- Reproduced the growth bug with a headless-Chromium probe before fixing:
  `canvas.height` climbed from 2661px to 8152px over 5 seconds with zero
  user interaction, and `body.scrollHeight` grew on every scroll.
- Re-ran the same probe after the fix: `canvas.height` holds steady
  indefinitely, and repeated scrolling no longer changes `scrollHeight`.
- Verified the O(n) token-sum refactor produces identical output to the
  old O(n^2) version on a sample dataset.
- Verified both pinned CDN URLs resolve (200 OK) and the page's inline
  script still passes `node --check` after the edits.