### PR TITLE
fix(skills): move mirror note below frontmatter in budget-negotiator

### DIFF
--- a/skills/budget-negotiator/SKILL.md
+++ b/skills/budget-negotiator/SKILL.md
@@ -1,11 +1,12 @@
-<!-- 
-  NOTE: This template is a mirror of skills/budget-negotiator/SKILL.md. 
-  Any changes made here must be kept byte-identical to the source skill.
--->
 ---
 name: budget-negotiator
 description: An advanced skill for L3 autonomous loops. When the token budget nears exhaustion, the agent analyzes its ROI and autonomously drafts a negotiation request for a budget increase rather than silently failing.
 ---
+
+<!--
+  NOTE: This template is a mirror of skills/budget-negotiator/SKILL.md.
+  Any changes made here must be kept byte-identical to the source skill.
+-->
 
 # Budget Negotiator
 

--- a/templates/SKILL.md.budget-negotiator
+++ b/templates/SKILL.md.budget-negotiator
@@ -1,11 +1,12 @@
-<!-- 
-  NOTE: This template is a mirror of skills/budget-negotiator/SKILL.md. 
-  Any changes made here must be kept byte-identical to the source skill.
--->
 ---
 name: budget-negotiator
 description: An advanced skill for L3 autonomous loops. When the token budget nears exhaustion, the agent analyzes its ROI and autonomously drafts a negotiation request for a budget increase rather than silently failing.
 ---
+
+<!--
+  NOTE: This template is a mirror of skills/budget-negotiator/SKILL.md.
+  Any changes made here must be kept byte-identical to the source skill.
+-->
 
 # Budget Negotiator
 


### PR DESCRIPTION
## Problem

`skills/budget-negotiator/SKILL.md` opens with an HTML comment *above* the `---` frontmatter delimiter:

```markdown
<!--
  NOTE: This template is a mirror of skills/budget-negotiator/SKILL.md.
  ...
-->
---
name: budget-negotiator
description: An advanced skill for L3 autonomous loops. ...
---
```

Because `---` is not the first line, the YAML frontmatter is never recognised. Claude Code's skill registry loads the skill with no `name` and advertises its description as the literal string `<!--`, so `budget-negotiator` is effectively undiscoverable — the agent can't tell what it's for.

It's the only `SKILL.md` in the repo with this layout; every other skill starts with `---` on line 1.

## Fix

Move the note below the frontmatter block. Same content, same file, just after the closing `---`.

Applied to both `skills/budget-negotiator/SKILL.md` and `templates/SKILL.md.budget-negotiator`, since the note itself requires the two to stay byte-identical. Trailing whitespace on the comment lines is dropped in both so they still match exactly (also satisfies `markdownlint` MD009).

## Verification

Both files parse:

```
skills/budget-negotiator/SKILL.md    -> frontmatter OK: name: budget-negotiator
templates/SKILL.md.budget-negotiator -> frontmatter OK: name: budget-negotiator
```

And remain byte-identical — `md5sum` on both: `7715893e316710fc26b8fb4faa7a937a`.

Body content is unchanged; the diff is header reordering only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)