### PR TITLE
fix(ci): skip star-history when STAR_HISTORY_TOKEN is unset

### DIFF
--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -17,27 +17,36 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Generate static star-history SVGs
+        id: generate
         env:
           GH_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}
+          # Chart the repo this workflow runs on (upstream or fork).
+          STAR_HISTORY_REPO: ${{ github.repository }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::STAR_HISTORY_TOKEN secret is required. GITHUB_TOKEN cannot list stargazers since GitHub's Jul 2026 API restriction — add a fine-grained PAT with read access to this repository (see scripts/generate-star-history.py)."
-            exit 1
+            # GITHUB_TOKEN cannot list stargazers (GitHub Jul 2026 restriction).
+            # Forks and clones without STAR_HISTORY_TOKEN should not fail daily CI.
+            echo "::notice::STAR_HISTORY_TOKEN not set — skipping star-history update. To enable: add a fine-grained PAT with read access to this repository as the STAR_HISTORY_TOKEN secret (see scripts/generate-star-history.py)."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
           python3 scripts/generate-star-history.py
 
       - name: Run validate gates (for PR status)
         id: validate_gates
+        if: steps.generate.outputs.skipped != 'true'
         continue-on-error: true
         run: bash scripts/ci-validate-gates.sh
 
       - name: Run audit gates (for PR status)
         id: audit_gates
+        if: steps.generate.outputs.skipped != 'true'
         continue-on-error: true
         run: bash scripts/ci-audit-gates.sh
 
       - name: Fail the run if either gate failed
-        if: steps.validate_gates.outcome == 'failure' || steps.audit_gates.outcome == 'failure'
+        if: steps.generate.outputs.skipped != 'true' && (steps.validate_gates.outcome == 'failure' || steps.audit_gates.outcome == 'failure')
         run: |
           echo "validate gates: ${{ steps.validate_gates.outcome }}"
           echo "audit gates:    ${{ steps.audit_gates.outcome }}"
@@ -46,6 +55,7 @@ jobs:
 
       - name: Open PR for chart SVGs if changed
         id: pr
+        if: steps.generate.outputs.skipped != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -89,7 +99,7 @@ jobs:
           gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
 
       - name: Post required commit statuses for branch protection
-        if: steps.pr.outputs.opened == 'true'
+        if: steps.generate.outputs.skipped != 'true' && steps.pr.outputs.opened == 'true'
         uses: actions/github-script@v9
         with:
           script: |

--- a/LOOP.md
+++ b/LOOP.md
@@ -83,7 +83,7 @@ bash scripts/before-after-demo.sh
 |------|-------|------------|-------|
 | Daily Triage | L1 | ✅ `daily-triage.yml` | Weekdays; updates `STATE.md` + `loop-run-log.md` |
 | Changelog Drafter | L1 | ✅ `changelog-drafter.yml` | Mondays; opens release-prep issue |
-| Star History | L1 | ✅ `update-star-history.yml` | Daily; auto-PR to `main`; needs `STAR_HISTORY_TOKEN` secret (PAT) |
+| Star History | L1 | ✅ `update-star-history.yml` | Daily; auto-PR to `main`; needs `STAR_HISTORY_TOKEN` secret (PAT). Skips (success) if secret unset — safe for forks |
 | Validate + Audit | L1 | ✅ `validate-patterns.yml`, `audit.yml` | On PR + push; readiness score on PRs |
 | Dependabot | L1 | ✅ `.github/dependabot.yml` | Weekly npm (`loop-audit`, `loop-init`) + GitHub Actions |
 | PR Babysitter | L2 | ⏸ Manual | Maintainer `/loop` or `starters/pr-babysitter` — no Action yet |

--- a/scripts/generate-star-history.py
+++ b/scripts/generate-star-history.py
@@ -2,9 +2,10 @@
 """Generate a static star-history timeline SVG from GitHub stargazers data.
 
 Used while api.star-history.com live embeds are unavailable (GitHub restricted
-stargazer API access for third-party services, Jul 2026). CI requires the
+stargazer API access for third-party services, Jul 2026). CI uses the
 ``STAR_HISTORY_TOKEN`` repo secret (fine-grained PAT with read access to this
-repo). Locally, use ``gh auth`` / ``GH_TOKEN``.
+repo). If the secret is unset, ``update-star-history.yml`` skips cleanly so
+forks without a PAT do not fail daily. Locally, use ``gh auth`` / ``GH_TOKEN``.
 
 Interactive browser UI (token in localStorage): docs/star-history.html
 """


### PR DESCRIPTION
## Summary
- Forks (e.g. `nivinlabs/loop-engineering`) schedule `update-star-history.yml` but lack `STAR_HISTORY_TOKEN`, so daily runs fail hard after GitHub’s Jul 2026 stargazer API restriction.
- When the secret is missing, skip chart generation with a notice and exit successfully; skip validate/audit/PR steps.
- When present, set `STAR_HISTORY_REPO` from `github.repository` so forks can opt in with their own PAT.

Fixes recurring failures like https://github.com/nivinlabs/loop-engineering/actions/runs/31074178342 (after the fork merges this change, or sets the secret).

## Test plan
- [ ] On `cobusgreyling/loop-engineering` (secret set): workflow_dispatch still generates SVGs / opens PR when charts change
- [ ] On a fork without `STAR_HISTORY_TOKEN`: job succeeds with skip notice, no PR opened
- [ ] Confirm validate/audit steps are not run when skipped