### PR TITLE
fix(goal-audit): commit empty-fixture dir; guard append-run-log JSON; document --fix alias

### DIFF
--- a/scripts/append-run-log.mjs
+++ b/scripts/append-run-log.mjs
@@ -16,7 +16,13 @@ if (!entryJson) {
   process.exit(1);
 }
 
-const entry = JSON.parse(entryJson);
+let entry;
+try {
+  entry = JSON.parse(entryJson);
+} catch {
+  console.error('Usage: second argument must be a valid JSON object');
+  process.exit(1);
+}
 const content = await readFile(logPath, 'utf8');
 const markerAt = content.indexOf(MARKER);
 if (markerAt === -1) {

--- a/tools/goal-audit/src/cli.ts
+++ b/tools/goal-audit/src/cli.ts
@@ -19,6 +19,7 @@ Options:
   --json      JSON output (for CI / scripting)
   --md        Markdown report
   --suggest   Show copy-from-template commands
+  --fix       Alias for --suggest (prints commands, does not modify files)
   --help, -h  This help
 
 Scores goal readiness for Grok Build /goal:


### PR DESCRIPTION
## Summary
Three small, independently verifiable fixes:

1. **fix(goal-audit): commit the empty test fixture** – `test/auditor.test.mjs` audits `fixtures/fixtures-empty`, but git cannot track empty directories, so the `empty temp dir` test was silently auditing a *nonexistent* path (it only passes because `fileExists` returns `false` for missing paths). Added `.gitkeep` so the test targets a real empty directory as its name claims. Verified: `cd tools/goal-audit && npm test` → 2/2 pass.

2. `fix(scripts): guard append-run-log entry JSON` – `append-run-log.mjs:19` ran `JSON.parse(entryJson)` unguarded, dumping a raw stack trace on malformed input, inconsistent with the script's own guarded parsing of existing log lines. Wrapped in try/catch with a clean usage error, exit 1.

3. `docs(goal-audit): document --fix` — the CLI accepts `--fix` as an alias for `--suggest` but it was undocumented and its name implies it modifies files. Help text now clarifies it only prints commands.

## Checklist
- [x] Changes verified locally (`npm test` for goal-audit, manual run of append-run-log.mjs for valid and invalid JSON)
- [x] No functional changes to existing behavior