### PR TITLE
fix(goal-audit): commit empty-fixture dir; guard append-run-log JSON; document --fix alias

### DIFF
--- a/scripts/append-run-log.mjs
+++ b/scripts/append-run-log.mjs
@@ -16,7 +16,13 @@ if (!entryJson) {
   process.exit(1);
 }
 
-const entry = JSON.parse(entryJson);
+let entry;
+try {
+  entry = JSON.parse(entryJson);
+} catch {
+  console.error('Usage: second argument must be a valid JSON object');
+  process.exit(1);
+}
 const content = await readFile(logPath, 'utf8');
 const markerAt = content.indexOf(MARKER);
 if (markerAt === -1) {

--- a/tools/goal-audit/src/cli.ts
+++ b/tools/goal-audit/src/cli.ts
@@ -19,6 +19,7 @@ Options:
   --json      JSON output (for CI / scripting)
   --md        Markdown report
   --suggest   Show copy-from-template commands
+  --fix       Alias for --suggest (prints commands, does not modify files)
   --help, -h  This help
 
 Scores goal readiness for Grok Build /goal:


### PR DESCRIPTION
Guard invalid JSON in scripts/append-run-log.mjs (print Usage and exit 1 instead of stacktrace), document the already-implemented --fix alias in goal-audit --help, and track the empty fixture directory via .gitkeep.

Verification:
- node --check ok for both files
- invalid JSON -> Usage exit 1
- goal-audit --help now shows --fix, --suggest and --fix produce identical output
- --json/--md ok, fixtures-empty correctly scores G0
- npm test in tools/goal-audit -> 2/2 pass

Small, focused fix with no breaking changes.