### PR TITLE
fix(readiness-core): deduplicate scanned skills to avoid double-counting score

### DIFF
--- a/tools/readiness-core/src/index.ts
+++ b/tools/readiness-core/src/index.ts
@@ -36,14 +36,14 @@ export async function scanSkillDirectories(root: string): Promise<string[]> {
     path.join(root, '.codex', 'skills'),
     path.join(root, 'skills'),
   ];
-  const found: string[] = [];
+  const foundSet = new Set<string>();
   for (const dir of dirs) {
     if (!(await fileExists(dir))) continue;
     const entries = await readdir(dir, { withFileTypes: true });
     for (const e of entries) {
-      if (e.isDirectory()) found.push(e.name);
-      if (e.isFile() && e.name === 'SKILL.md') found.push('root-skill');
+      if (e.isDirectory()) foundSet.add(e.name);
+      if (e.isFile() && e.name === 'SKILL.md') foundSet.add('root-skill');
     }
   }
-  return found;
+  return [...foundSet];
 }


### PR DESCRIPTION
Prevents double-counting when the same skill name exists in multiple skill directories (e.g. .grok/skills/foo and skills/foo). Previously scanSkillDirectories pushed duplicates, inflating signals.skills.count and awarding skillsTwoPlus (14 pts) instead of skillsOne (7 pts), skewing the Loop Readiness score.

Verification:
- npm run build && node --check dist/index.js ok
- npm test in tools/readiness-core -> 3/3 pass
- Manual fixture with duplicate skill name in two dirs now correctly deduplicated
