### PR TITLE
docs: document root npm ci for registry validation scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,14 @@ Also add an entry to `patterns/registry.yaml`.
 - Include at least one failure or surprise
 - Actionable lesson in one paragraph
 
+## Development Setup
+
+```bash
+npm ci   # at repo root – installs yaml/ajv for scripts/validate-registry.mjs
+npm run validate:registry
+npm run check:loop-init
+```
+
 ## Pull Request Checklist
 
 - [ ] Links work from README or relevant index


### PR DESCRIPTION
Docs: running `scripts/validate-registry.mjs` and `scripts/check-loop-init-sync.mjs` requires `yaml`/`ajv` at repo root. The error `ERR_MODULE_NOT_FOUND: yaml` appears after a fresh clone if only `tools/*/npm ci` was run. CONTRIBUTING now documents `npm ci` at repo root before `validate:registry`.

Verification:
- Fresh clone without root `npm ci` reproduces the error (observed)
- After `npm ci` at root, `npm run validate:registry` and `npm run check:loop-init` pass
