### PR TITLE
Add CRLF frontmatter regression tests for loop-sync

### DIFF
--- a/tools/loop-sync/dist/sync.d.ts
+++ b/tools/loop-sync/dist/sync.d.ts
@@ -30,6 +30,13 @@ export interface SyncOptions {
     json?: boolean;
 }
 /**
+ * Extract frontmatter from markdown files
+ */
+export declare function extractFrontmatter(content: string): {
+    frontmatter: Record<string, string>;
+    body: string;
+};
+/**
  * Main sync function
  */
 export declare function runSync(options: SyncOptions): Promise<DriftReport>;

--- a/tools/loop-sync/dist/sync.js
+++ b/tools/loop-sync/dist/sync.js
@@ -36,15 +36,15 @@ async function readFileContent(filePath) {
 /**
  * Extract frontmatter from markdown files
  */
-function extractFrontmatter(content) {
+export function extractFrontmatter(content) {
     const frontmatter = {};
     let body = content;
-    if (content.startsWith('---')) {
-        const endIndex = content.indexOf('---', 3);
+    if (content.startsWith('---\n') || content.startsWith('---\r\n')) {
+        const endIndex = content.indexOf('\n---', 3);
         if (endIndex !== -1) {
             const fmContent = content.slice(3, endIndex);
-            body = content.slice(endIndex + 3);
-            for (const line of fmContent.split('\n')) {
+            body = content.slice(endIndex + 4);
+            for (const line of fmContent.split(/\r?\n/)) {
                 const colonIndex = line.indexOf(':');
                 if (colonIndex !== -1) {
                     const key = line.slice(0, colonIndex).trim();

--- a/tools/loop-sync/src/sync.ts
+++ b/tools/loop-sync/src/sync.ts
@@ -63,7 +63,7 @@ async function readFileContent(filePath: string): Promise<string | null> {
 /**
  * Extract frontmatter from markdown files
  */
-function extractFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
+export function extractFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
   const frontmatter: Record<string, string> = {};
   let body = content;
   

--- a/tools/loop-sync/test/sync.test.mjs
+++ b/tools/loop-sync/test/sync.test.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { runSync, formatReport } from '../dist/sync.js';
+import { runSync, formatReport, extractFrontmatter } from '../dist/sync.js';
 
 const testDir = path.join(process.cwd(), '.test-tmp');
 const exec = promisify(execFile);
@@ -80,6 +80,31 @@ describe('runSync', () => {
   test('provides suggestions', async () => {
     const report = await runSync({ targetDir: testDir, ...baseOpts });
     assert.ok(report.suggestions.length > 0);
+  });
+});
+
+describe('extractFrontmatter', () => {
+  test('parses LF frontmatter', () => {
+    const { frontmatter, body } = extractFrontmatter('---\nname: demo\nversion: 1.0.0\n---\nBody text\n');
+
+    assert.deepEqual(frontmatter, { name: 'demo', version: '1.0.0' });
+    assert.match(body, /Body text/);
+  });
+
+  test('parses CRLF frontmatter without trailing \\r in keys or values', () => {
+    const { frontmatter, body } = extractFrontmatter('---\r\nname: demo\r\nversion: 1.0.0\r\n---\r\nBody text\r\n');
+
+    assert.deepEqual(frontmatter, { name: 'demo', version: '1.0.0' });
+    assert.ok(Object.keys(frontmatter).every((key) => !key.endsWith('\r')));
+    assert.match(body, /Body text/);
+  });
+
+  test('rejects opening fence without newline', () => {
+    const content = '---hello\nname: demo\n---\nBody text\n';
+    const { frontmatter, body } = extractFrontmatter(content);
+
+    assert.deepEqual(frontmatter, {});
+    assert.equal(body, content);
   });
 });
 


### PR DESCRIPTION
Fixes #479

Adds regression tests for `extractFrontmatter` in `tools/loop-sync`, locking in the CRLF fix from #476:

- LF frontmatter still parses (existing behaviour)
- CRLF frontmatter (`---\r\nkey: value\r\n---\r\nbody`) parses keys and values without trailing `\r`
- `---hello` (no newline after the opening fence) is rejected: empty frontmatter, body returned unchanged

Notes:

- `extractFrontmatter` was module-private, so it is now exported from `src/sync.ts` to let the tests exercise it directly.
- The committed `dist/sync.js` was stale relative to the `src/sync.ts` fix from #476 (it still had the pre-fix `startsWith('---')` logic), so `dist` is rebuilt in this PR. Without the rebuild, the `---hello` rejection test fails against the committed dist.

Suite results (`cd tools/loop-sync && npm test`): 10 tests, 10 pass, 0 fail.