### PR TITLE
test(loop-sync): add CRLF frontmatter regression tests

### DIFF
--- a/tools/loop-sync/dist/sync.d.ts
+++ b/tools/loop-sync/dist/sync.d.ts
@@ -30,6 +30,13 @@ export interface SyncOptions {
     json?: boolean;
 }
 /**
+ * Extract frontmatter from markdown files
+ */
+export declare function extractFrontmatter(content: string): {
+    frontmatter: Record<string, string>;
+    body: string;
+};
+/**
  * Main sync function
  */
 export declare function runSync(options: SyncOptions): Promise<DriftReport>;

--- a/tools/loop-sync/dist/sync.js
+++ b/tools/loop-sync/dist/sync.js
@@ -36,15 +36,16 @@ async function readFileContent(filePath) {
 /**
  * Extract frontmatter from markdown files
  */
-function extractFrontmatter(content) {
+export function extractFrontmatter(content) {
     const frontmatter = {};
     let body = content;
-    if (content.startsWith('---')) {
-        const endIndex = content.indexOf('---', 3);
-        if (endIndex !== -1) {
+    if (content.startsWith('---\n') || content.startsWith('---\r\n')) {
+        const endIndex = content.indexOf('\n---', 3);
+        if (endIndex !== -1 && (endIndex + 4 === content.length || content[endIndex + 4] === '\n' || content[endIndex + 4] === '\r')) {
             const fmContent = content.slice(3, endIndex);
-            body = content.slice(endIndex + 3);
-            for (const line of fmContent.split('\n')) {
+            const closingEnd = content.indexOf('\n', endIndex + 4);
+            body = closingEnd === -1 ? content.slice(endIndex + 1) : content.slice(closingEnd + 1);
+            for (const line of fmContent.split(/\r?\n/)) {
                 const colonIndex = line.indexOf(':');
                 if (colonIndex !== -1) {
                     const key = line.slice(0, colonIndex).trim();

--- a/tools/loop-sync/src/sync.ts
+++ b/tools/loop-sync/src/sync.ts
@@ -63,15 +63,16 @@ async function readFileContent(filePath: string): Promise<string | null> {
 /**
  * Extract frontmatter from markdown files
  */
-function extractFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
+export function extractFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
   const frontmatter: Record<string, string> = {};
   let body = content;
   
   if (content.startsWith('---\n') || content.startsWith('---\r\n')) {
     const endIndex = content.indexOf('\n---', 3);
-    if (endIndex !== -1) {
+    if (endIndex !== -1 && (endIndex + 4 === content.length || content[endIndex + 4] === '\n' || content[endIndex + 4] === '\r')) {
       const fmContent = content.slice(3, endIndex);
-      body = content.slice(endIndex + 4);
+      const closingEnd = content.indexOf('\n', endIndex + 4);
+      body = closingEnd === -1 ? content.slice(endIndex + 1) : content.slice(closingEnd + 1);
       
       for (const line of fmContent.split(/\r?\n/)) {
         const colonIndex = line.indexOf(':');

--- a/tools/loop-sync/test/sync.test.mjs
+++ b/tools/loop-sync/test/sync.test.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { runSync, formatReport } from '../dist/sync.js';
+import { runSync, formatReport, extractFrontmatter } from '../dist/sync.js';
 
 const testDir = path.join(process.cwd(), '.test-tmp');
 const exec = promisify(execFile);
@@ -115,6 +115,36 @@ describe('formatReport', () => {
 
     assert.match(formatted, /AGENTS\.md/);
     assert.match(formatted, /missing/i);
+  });
+});
+
+describe('extractFrontmatter', () => {
+  test('parses LF frontmatter', () => {
+    const { frontmatter, body } = extractFrontmatter(
+      '---\nkey: value\n---\nbody text\n',
+    );
+    assert.deepEqual(frontmatter, { key: 'value' });
+    assert.equal(body, 'body text\n');
+  });
+
+  test('parses CRLF frontmatter without trailing carriage returns', () => {
+    const { frontmatter, body } = extractFrontmatter(
+      '---\r\nkey: value\r\nother: thing\r\n---\r\nbody text\r\n',
+    );
+    assert.deepEqual(frontmatter, { key: 'value', other: 'thing' });
+    assert.ok(!Object.values(frontmatter).some((v) => v.endsWith('\r')));
+    assert.ok(!Object.keys(frontmatter).some((k) => k.endsWith('\r')));
+    assert.equal(body, 'body text\r\n');
+  });
+
+  test('rejects opening fence without newline (---hello)', () => {
+    const { frontmatter } = extractFrontmatter('---hello\nkey: value\n---\n');
+    assert.deepEqual(frontmatter, {});
+  });
+
+  test('rejects closing fence without preceding newline', () => {
+    const { frontmatter } = extractFrontmatter('---\nkey: value\n---oops\n');
+    assert.deepEqual(frontmatter, {});
   });
 });
 


### PR DESCRIPTION
Closes #479

Adds regression tests for `extractFrontmatter` CRLF handling (fixed in #476):
- LF frontmatter still parses
- CRLF frontmatter parses keys without trailing `\r`
- `---hello` (opening fence without newline) is rejected
- Closing fence without newline is rejected

Exports `extractFrontmatter` from `src/sync.ts` so the tests can exercise it directly, and fixes a body-slicing off-by-one that the new tests exposed (the closing fence's newline was duplicated into the body).

`cd tools/loop-sync && npm test` passes (11 tests).