### PR TITLE
test(readiness-core): add skill-dedup regression test

### DIFF
--- a/tools/readiness-core/test/index.test.mjs
+++ b/tools/readiness-core/test/index.test.mjs
@@ -14,6 +14,46 @@ test('fileExists returns false for missing file', async () => {
   assert.strictEqual(result, false);
 });
 
+test('scanSkillDirectories deduplicates skill names across scan roots', async () => {
+  const fixtureDir = path.join(process.cwd(), '.test-fixture-dedup');
+  await fs.rm(fixtureDir, { recursive: true, force: true });
+  // Same skill directory name under two different roots
+  await fs.mkdir(path.join(fixtureDir, '.grok', 'skills', 'foo'), { recursive: true });
+  await fs.mkdir(path.join(fixtureDir, 'skills', 'foo'), { recursive: true });
+  // A distinct skill that must still be counted
+  await fs.mkdir(path.join(fixtureDir, 'skills', 'bar'), { recursive: true });
+
+  const skills = await scanSkillDirectories(fixtureDir);
+  assert.ok(Array.isArray(skills));
+  const countByName = (name) => skills.filter((s) => s === name).length;
+  assert.equal(countByName('foo'), 1, 'foo appears once despite existing in .grok/skills and skills');
+  assert.equal(countByName('bar'), 1, 'distinct skill bar still appears');
+  assert.equal(skills.length, 2, 'two distinct skill names total');
+
+  await fs.rm(fixtureDir, { recursive: true, force: true });
+});
+
+test('skill dedup matters because readiness score signals skillsOne vs skillsTwoPlus', async () => {
+  // Regression guard: scanSkillDirectories is the source used by the
+  // readiness score to decide between skillsOne and skillsTwoPlus. If a
+  // skill duplicated across .grok/skills and skills were counted twice,
+  // a project with only one real skill would be scored as skillsTwoPlus.
+  const fixtureDir = path.join(process.cwd(), '.test-fixture-dedup-score');
+  await fs.rm(fixtureDir, { recursive: true, force: true });
+  await fs.mkdir(path.join(fixtureDir, '.grok', 'skills', 'foo'), { recursive: true });
+  await fs.mkdir(path.join(fixtureDir, 'skills', 'foo'), { recursive: true });
+
+  const skills = await scanSkillDirectories(fixtureDir);
+  const uniqueNames = new Set(skills);
+  assert.equal(uniqueNames.size, 1);
+  assert.ok(
+    uniqueNames.size < 2,
+    'one real skill must not be misreported as two or more (skillsTwoPlus inflation)',
+  );
+
+  await fs.rm(fixtureDir, { recursive: true, force: true });
+});
+
 test('scanSkillDirectories finds skills in target directory', async () => {
   // We can test this by running it on a known directory or setting up a mock
   // For simplicity, let's scan the current directory and ensure it handles empty or missing gracefully.


### PR DESCRIPTION
Closes #480

Adds regression tests for the skill-dedup fix in #475:
- Same skill directory name under `.grok/skills` and `skills` → `scanSkillDirectories` returns count 1
- Distinct skill names still count separately
- Documents why dedup matters: one real skill must not inflate `skillsOne` into `skillsTwoPlus` in the readiness score

Uses temp fixture dirs (cleaned up after), no permanent fixtures.

`cd tools/readiness-core && npm test` passes (5 tests).