### PR TITLE
test(scripts): add invalid-JSON smoke test for append-run-log

### DIFF
--- a/scripts/append-run-log.test.mjs
+++ b/scripts/append-run-log.test.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for scripts/append-run-log.mjs.
+ * Run directly (node scripts/append-run-log.test.mjs) or via the validate gates.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, writeFile, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const exec = promisify(execFile);
+const SCRIPT = new URL('./append-run-log.mjs', import.meta.url).pathname;
+
+test('invalid JSON second arg exits 1 with a Usage / valid JSON message', async () => {
+  await assert.rejects(
+    exec('node', [SCRIPT, 'not-json', 'ignored.log']),
+    (err) => {
+      assert.equal(err.code, 1);
+      const msg = `${err.stderr}${err.stdout}`;
+      assert.match(msg, /Usage|valid JSON/i);
+      return true;
+    },
+  );
+});
+
+test('valid minimal JSON entry does not throw on parse', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'append-run-log-'));
+  const logPath = path.join(dir, 'loop-run-log.md');
+  await writeFile(logPath, '<!-- Loop appends below this line -->\n');
+  try {
+    const entry = JSON.stringify({ run_id: 'run-1', outcome: 'ok' });
+    const { stdout } = await exec('node', [SCRIPT, entry, logPath]);
+    assert.match(stdout, /Appended run run-1/);
+    const written = await readFile(logPath, 'utf8');
+    assert.ok(written.includes('"run_id":"run-1"'));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/ci-validate-gates.sh
+++ b/scripts/ci-validate-gates.sh
@@ -35,6 +35,9 @@ npm install --no-save yaml@2 ajv@8
 node scripts/validate-registry.mjs
 node scripts/check-loop-init-sync.mjs
 
+echo "Smoke-testing scripts…"
+node scripts/append-run-log.test.mjs
+
 echo "Building and testing readiness-core…"
 (
   cd tools/readiness-core


### PR DESCRIPTION
Closes #481

Adds `scripts/append-run-log.test.mjs` (node:test, no deps):
- Invalid JSON second arg → exit code 1 with a Usage / valid-JSON message
- Valid minimal JSON entry appends without throwing (temp log file)

Wired into `scripts/ci-validate-gates.sh` so it runs in the validate gates. No secrets, small change.