### PR TITLE
fix(loop-init): replace retired claude-sonnet-4 identifier in foundry stack

### DIFF
--- a/tools/loop-init/src/cli.ts
+++ b/tools/loop-init/src/cli.ts
@@ -241,7 +241,7 @@ function foundryStackYaml(
         ? minimaxInterfaceYaml(model, region)
         : `    - primitive: model/anthropic
       config:
-        model: claude-sonnet-4-20250514`;
+        model: claude-sonnet-4-6`;
     return `name: ${stackName}
 version: 1.0.0
 description: "loop-engineering ${pattern} → implementer harness (loop-init --with-foundry)"


### PR DESCRIPTION
## Summary

`loop-init --with-foundry` scaffolds an implementer stack pinned to `claude-sonnet-4-20250514`, which Anthropic retired on the Claude API on 15 June 2026. The generated `stack.yaml` therefore fails on first run. This swaps it for the replacement Anthropic lists for that model, `claude-sonnet-4-6`.

## Changes

- [x] Tool change (`tools/loop-init`)
- [ ] New pattern or starter
- [ ] Doc / example improvement
- [ ] Story

One line in `tools/loop-init/src/cli.ts`, in `foundryStackYaml()`'s `model/anthropic` interface layer. Nothing else touched.

### Note on `dist/`

`tools/loop-init/dist/cli.js` is committed and holds the same string, but it is build output from `npm run build`. I left it untouched rather than hand-editing generated code — it will pick this up on the next build.

## Checklist

- [x] No secrets, tokens, internal company URLs
- [x] No other model identifiers changed, no refactoring
- [ ] `node tools/loop-audit/dist/cli.js .` — could not run, see below

## Testing

Clean clone, isolated environment:

- `tsc --noEmit`: clean
- test suite before the change: 59 tests, 58 pass, 1 fail
- test suite after the change: 59 tests, 58 pass, 1 fail, same test

The single failure is pre-existing and unrelated: `loop-init prints Loop Ready score after scaffold`. `npm ci` in `tools/loop-init` cannot resolve `@cobusgreyling/loop-audit@^1.8.0` — npm currently publishes up to 1.7.0 — so that test has no audit binary to call, and for the same reason I could not tick the loop-audit checklist item. I ran the suite with TypeScript installed out-of-tree to work around the install failure. That version pin may be worth a separate look.

On sampling parameters: the generated stack sets no `temperature`, and Sonnet 4.6 sits below the Opus 4.7 threshold where non-default `temperature` / `top_p` / `top_k` are rejected. So this is a plain identifier swap with no change to the request shape.