### PR TITLE
fix(docs): serve README images via jsDelivr (raw.githubusercontent 503s)

### DIFF
--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -98,6 +98,11 @@ jobs:
           echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
 
+          # README/showcase serve charts via jsDelivr (@main). Purge so the
+          # next visit is not stuck on a stale cached SVG after merge lands.
+          curl -fsS "https://purge.jsdelivr.net/gh/${{ github.repository }}@main/assets/visuals/star-history.svg" || true
+          curl -fsS "https://purge.jsdelivr.net/gh/${{ github.repository }}@main/assets/visuals/star-history-dark.svg" || true
+
       - name: Post required commit statuses for branch protection
         if: steps.generate.outputs.skipped != 'true' && steps.pr.outputs.opened == 'true'
         uses: actions/github-script@v9

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@
 
 <p align="center">
   <a href="https://cobusgreyling.github.io/loop-engineering/">
-    <img src="assets/visuals/loop-engineering-logo.svg" alt="Loop Engineering logo" width="88" />
+    <img src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/loop-engineering-logo.svg" alt="Loop Engineering logo" width="88" />
   </a>
 </p>
 
 > **Stop prompting. Design the loop. Get a score.**
 
 <p align="center">
-  <img src="assets/visuals/LE5.jpeg" alt="Loop Engineering — design the system that prompts your agents" width="100%" />
+  <img src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/LE5.jpeg" alt="Loop Engineering — design the system that prompts your agents" width="100%" />
 </p>
 
 <p align="center">
@@ -55,7 +55,7 @@ npx @cobusgreyling/loop doctor .
 
 <p align="center">
   <a href="docs/QUICKSTART.md">
-    <img src="assets/visuals/loop-audit-demo.gif" alt="Loop Ready score climbs from 10 to 100 in 15 seconds" width="100%" />
+    <img src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/loop-audit-demo.gif" alt="Loop Ready score climbs from 10 to 100 in 15 seconds" width="100%" />
   </a>
 </p>
 
@@ -152,7 +152,7 @@ memory-engineering → loop-engineering → harness-foundry → outerloop → fl
 | [Add your project](https://github.com/cobusgreyling/loop-engineering/discussions/92) | **Pinned:** Loop Ready badge + adopters list |
 
 <p align="center">
-  <img src="assets/visuals/section-divider.svg" alt="" width="100%" />
+  <img src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/section-divider.svg" alt="" width="100%" />
 </p>
 
 ## Why This Matters
@@ -181,13 +181,13 @@ Full detail: [docs/primitives.md](docs/primitives.md) · Cross-tool matrix: [doc
 ### Visual Overview
 
 <p align="center">
-  <img src="assets/visuals/primitives-infographic.jpg" alt="The Five Building Blocks + Memory — Loop Engineering" width="100%" />
+  <img src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/primitives-infographic.jpg" alt="The Five Building Blocks + Memory — Loop Engineering" width="100%" />
 </p>
 
 ### Anatomy of a Loop
 
 <p align="center">
-  <img src="assets/visuals/loop-cycle-animated.svg" alt="Animated loop flow — schedule, triage, state, worktree, implement, verify, MCP, human gate" width="100%" />
+  <img src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/loop-cycle-animated.svg" alt="Animated loop flow — schedule, triage, state, worktree, implement, verify, MCP, human gate" width="100%" />
 </p>
 
 <details>
@@ -217,7 +217,7 @@ Deeper diagrams — the actor-level sequence within one run, the run lifecycle's
 ## Patterns
 
 <p align="center">
-  <img src="assets/visuals/patterns-overview.svg" alt="Seven production loop patterns with cadence and token cost" width="100%" />
+  <img src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/patterns-overview.svg" alt="Seven production loop patterns with cadence and token cost" width="100%" />
 </p>
 
 | Pattern | Cadence | Starter | Week 1 | Token cost |
@@ -357,9 +357,9 @@ MIT
 <p align="center">
   <a href="https://cobusgreyling.github.io/loop-engineering/star-history.html">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="assets/visuals/star-history-dark.svg" />
-      <source media="(prefers-color-scheme: light)" srcset="assets/visuals/star-history.svg" />
-      <img alt="Star History Chart" src="assets/visuals/star-history.svg" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/star-history-dark.svg" />
+      <source media="(prefers-color-scheme: light)" srcset="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/star-history.svg" />
+      <img alt="Star History Chart" src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/star-history.svg" />
     </picture>
   </a>
 </p>

--- a/docs/distribution/v1.6.0-social-drafts.md
+++ b/docs/distribution/v1.6.0-social-drafts.md
@@ -6,7 +6,7 @@ Use these as-is or lightly edit. Goal: **score 10→100 in ~15s**, then point at
 
 - Release: https://github.com/cobusgreyling/loop-engineering/releases/tag/v1.6.0
 - Repo: https://github.com/cobusgreyling/loop-engineering
-- Demo GIF: https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/loop-audit-demo.gif
+- Demo GIF: https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/loop-audit-demo.gif
 - Showcase: https://cobusgreyling.github.io/loop-engineering/
 - Show your loop: https://github.com/cobusgreyling/loop-engineering/discussions/326
 - Story (Substack source): `stories/score-climbs-then-budget-burns.md`

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,9 +11,9 @@ title: Loop Engineering — Showcase
   <meta name="description" content="The practical reference for loop engineering. Patterns, starters, checklists, and tooling for Grok, Claude Code, Codex, OpenClaw, and Opencode.">
   <meta property="og:title" content="Loop Engineering">
   <meta property="og:description" content="Stop prompting. Design the loop. Get a score. Two npx commands.">
-  <meta property="og:image" content="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/loop-engineering-social-banner.jpg">
+  <meta property="og:image" content="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/loop-engineering-social-banner.jpg">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/showcase.css">
-  <link rel="icon" href="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/loop-engineering-logo.svg">
+  <link rel="icon" href="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/loop-engineering-logo.svg">
   <script type="module">
     import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.esm.min.mjs";
     mermaid.initialize({
@@ -43,7 +43,7 @@ title: Loop Engineering — Showcase
 <nav class="nav">
   <div class="wrap nav-inner">
     <a href="#" class="logo">
-      <img src="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/loop-engineering-logo.svg" alt="" width="28" height="28" style="vertical-align:-6px;margin-right:8px;border-radius:6px;" />
+      <img src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/loop-engineering-logo.svg" alt="" width="28" height="28" style="vertical-align:-6px;margin-right:8px;border-radius:6px;" />
       Loop <span>Engineering</span>
     </a>
     <button
@@ -97,7 +97,7 @@ npx @cobusgreyling/loop doctor .</pre>
   </div>
   <img
     class="hero-img"
-    src="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/loop-audit-demo.gif"
+    src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/loop-audit-demo.gif"
     alt="Loop Ready score climbs from 10 to 100"
     loading="lazy"
     style="margin-top:24px;"
@@ -125,7 +125,7 @@ npx @cobusgreyling/loop doctor .</pre>
   <p class="section-desc">You design it once. You're not prompting every micro-step.</p>
   <img
     class="hero-img"
-    src="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/loop-cycle-animated.svg"
+    src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/loop-cycle-animated.svg"
     alt="Anatomy of a loop — schedule, triage, state, worktree, implementer, verifier, MCP, human gate"
     loading="lazy"
     style="margin-bottom: 24px;"
@@ -348,7 +348,7 @@ flowchart TB
   <p class="section-desc">Documented loops with scheduling, skills, state schemas, verification, and honest failure modes.</p>
   <img
     class="hero-img"
-    src="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/patterns-overview.svg"
+    src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/patterns-overview.svg"
     alt="Seven production loop patterns — cadence and token cost overview"
     loading="lazy"
     style="margin-bottom: 28px;"
@@ -1059,7 +1059,7 @@ function setupMobileNav() {
 
 async function renderTelemetry() {
   try {
-    const res = await fetch('https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/loop-run-log.md');
+    const res = await fetch('https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/loop-run-log.md');
     const text = await res.text();
     
     // Parse JSON lines from the markdown file

--- a/docs/star-history.html
+++ b/docs/star-history.html
@@ -10,7 +10,7 @@ title: Star History — Loop Engineering
   <title>GitHub Star History — Loop Engineering</title>
   <meta name="description" content="View and compare GitHub star history for loop-engineering and other repos you own.">
   <meta name="theme-color" content="#363636">
-  <link rel="icon" href="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/loop-engineering-logo.svg">
+  <link rel="icon" href="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/loop-engineering-logo.svg">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/star-history.css">
 </head>
 <body>
@@ -101,9 +101,9 @@ title: Star History — Loop Engineering
       Default: <code>cobusgreyling/loop-engineering</code> — add comma-separated repos to compare.
       <div class="sh-static-fallback" style="margin-top:24px;">
         <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/star-history-dark.svg" />
-          <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/star-history.svg" />
-          <img alt="Static star history (CI-updated daily)" src="https://raw.githubusercontent.com/cobusgreyling/loop-engineering/main/assets/visuals/star-history.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/star-history-dark.svg" />
+          <source media="(prefers-color-scheme: light)" srcset="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/star-history.svg" />
+          <img alt="Static star history (CI-updated daily)" src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/star-history.svg" />
         </picture>
         <p>Static chart from CI. Live data needs your token (settings ⚙).</p>
       </div>


### PR DESCRIPTION
## Summary
- GitHub’s `raw.githubusercontent.com` CDN is intermittently returning **503** for every image under `assets/visuals/`, so the README and showcase show broken images even though the files are fine in git.
- Point README, showcase (`docs/index.html`), and star-history page image URLs at **jsDelivr** (`cdn.jsdelivr.net/gh/...@main/...`), which consistently returns 200 for the same files.
- After automated star-history SVG updates, purge jsDelivr cache so the chart does not stay stale.

## Test plan
- [x] `curl` all README asset URLs on jsDelivr → 200
- [x] Same URLs on `raw.githubusercontent.com` → 503 (reproduces outage)
- [ ] After merge: hard-refresh https://github.com/cobusgreyling/loop-engineering and confirm logo, LE5 hero, demo GIF, primitives, loop-cycle, patterns, star-history load