### PR TITLE
chore: hygiene — Help wanted, fast-uri 3.1.5, Dependabot root/mcp

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: "npm"
     directory: "/tools/loop-audit"
     schedule:
       interval: "weekly"
@@ -14,6 +21,13 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(loop-init)"
+  - package-ecosystem: "npm"
+    directory: "/tools/mcp-server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(mcp)"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/LOOP.md
+++ b/LOOP.md
@@ -85,7 +85,7 @@ bash scripts/before-after-demo.sh
 | Changelog Drafter | L1 | ✅ `changelog-drafter.yml` | Mondays; opens release-prep issue |
 | Star History | L1 | ✅ `update-star-history.yml` | Daily; auto-PR to `main`; needs `STAR_HISTORY_TOKEN` secret (PAT). Skips (success) if secret unset — safe for forks |
 | Validate + Audit | L1 | ✅ `validate-patterns.yml`, `audit.yml` | On PR + push; readiness score on PRs |
-| Dependabot | L1 | ✅ `.github/dependabot.yml` | Weekly npm (`loop-audit`, `loop-init`) + GitHub Actions |
+| Dependabot | L1 | ✅ `.github/dependabot.yml` | Weekly npm (root, `loop-audit`, `loop-init`, `mcp-server`) + GitHub Actions |
 | PR Babysitter | L2 | ⏸ Manual | Maintainer `/loop` or `starters/pr-babysitter` — no Action yet |
 | Dependency Sweeper | L2 | ⏸ Dependabot only | Patch PRs via Dependabot; full sweeper starter is manual |
 | CI Sweeper | L2 | ⏸ Partial | Reacts via failing validate/audit; no dedicated retry workflow |

--- a/README.md
+++ b/README.md
@@ -314,13 +314,11 @@ Addy Osmani:
 |------|-------|---------------|
 | ~10 min | [#120 — Adopters list](https://github.com/cobusgreyling/loop-engineering/issues/120) | One row in `docs/adopters.md` (or [Add Adopter](https://github.com/cobusgreyling/loop-engineering/issues/new?template=add-adopter.yml) template) |
 | ~15–20 min | [#118 — Daily Triage story](https://github.com/cobusgreyling/loop-engineering/issues/118) · [#173 — Issue Triage story](https://github.com/cobusgreyling/loop-engineering/issues/173) · [#119 — PR Babysitter failure](https://github.com/cobusgreyling/loop-engineering/issues/119) | Honest `stories/` write-up + index row |
-| ~20–25 min | [#483 — Windows notes](https://github.com/cobusgreyling/loop-engineering/issues/483) | Windows/CRLF landing notes in QUICKSTART (pain from #476) |
-| ~20–40 min | [#481 — append-run-log JSON test](https://github.com/cobusgreyling/loop-engineering/issues/481) · [#480 — skill-dedup test](https://github.com/cobusgreyling/loop-engineering/issues/480) · [#479 — loop-sync CRLF tests](https://github.com/cobusgreyling/loop-engineering/issues/479) | Regression tests locking fixes from #474–#476 |
-| ~40–45 min | [#387 — Hermes CI Sweeper](https://github.com/cobusgreyling/loop-engineering/issues/387) · [#388 — Hermes Issue Triage](https://github.com/cobusgreyling/loop-engineering/issues/388) · [#484 — Windsurf Post-Merge](https://github.com/cobusgreyling/loop-engineering/issues/484) · [#485 — Windsurf Changelog](https://github.com/cobusgreyling/loop-engineering/issues/485) | Fill pattern-coverage gaps in `examples/` |
+| ~40–45 min | [#388 — Hermes Issue Triage](https://github.com/cobusgreyling/loop-engineering/issues/388) | Hermes Issue Triage example in `examples/hermes/` |
 | Anytime | Templates | [Add Adopter](https://github.com/cobusgreyling/loop-engineering/issues/new?template=add-adopter.yml) · [Share a story](https://github.com/cobusgreyling/loop-engineering/issues/new?template=share-story.yml) |
 | Hubs | Discussions | [Show your loop](https://github.com/cobusgreyling/loop-engineering/discussions/326) · [Ask anything](https://github.com/cobusgreyling/loop-engineering/discussions/327) |
 
-**Recently shipped (thanks!):** @pxmpsdev — loop-sync CRLF tests (#496), readiness skill-dedup (#497), append-run-log invalid-JSON (#498), metrics unparseable run_id (#499). @shixi-li — Hermes CI Sweeper example (#500). Earlier: @pxmpsdev #474–#477.
+**Recently shipped (thanks!):** @AIMindCrafter — Windows/CRLF notes (#492), Windsurf Post-Merge Cleanup (#494), Windsurf Changelog Drafter (#495). @pxmpsdev — loop-sync CRLF tests (#496), readiness skill-dedup (#497), append-run-log invalid-JSON (#498), metrics unparseable run_id (#499). @shixi-li — Hermes CI Sweeper example (#500).
 
 **Docs/examples triage:** @AIMindCrafter co-owns `docs/`, `examples/`, and `stories/` (see [CODEOWNERS](CODEOWNERS) + [docs/area-owners.md](docs/area-owners.md)).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Leftover hygiene after the Aug 10–13 merge wave: Help wanted still listed shipped GFIs, and the only open Dependabot alert had no PR because root npm is not watched.

## Related issue

Closes the table gap after #492 / #494 / #495 / #496–#500. Addresses Dependabot alert #14 (`fast-uri` / [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7)).

## Changes

- [x] Doc / example / story improvement
- [x] Other

- README Help wanted: drop shipped #387, #479–#485; leave the 5 still-open GFIs (#118, #119, #120, #173, #388)
- Bump transitive `fast-uri` 3.1.4 → 3.1.5 in the root lockfile
- Watch `/` and `/tools/mcp-server` in Dependabot (LOOP.md note updated)

Already done on GitHub (not in this diff): closed #483 / #484 / #485 as completed.

## Checklist (from CONTRIBUTING)

- [x] Links work from README or the relevant index
- [x] No secrets, tokens, or internal company URLs
- [x] `STATE.md*` examples use `.example` suffix
- [x] If you touched the registry: n/a

## Testing / Dogfood

- [x] `npm update fast-uri --package-lock-only` resolved 3.1.5; `npm audit` reports 0 vulnerabilities at the root lockfile