### PR TITLE
fix(loop-worktree): don't crash gc() when a worktree dir was removed out-of-band

### DIFF
--- a/tools/loop-worktree/dist/worktree.js
+++ b/tools/loop-worktree/dist/worktree.js
@@ -215,7 +215,22 @@ async function gitWorktreePaths(root) {
         if (!line.startsWith('worktree '))
             continue;
         const abs = line.slice('worktree '.length).trim();
-        const absReal = await realpath(abs);
+        let absReal;
+        try {
+            absReal = await realpath(abs);
+        }
+        catch (err) {
+            // git keeps listing a worktree (as "prunable") even after its directory
+            // was removed out-of-band -- a manual `rm -rf`, a crash mid-cleanup, a
+            // container wipe -- rather than via `git worktree remove`. realpath()
+            // on that now-missing path throws ENOENT, which used to propagate out
+            // of gc() entirely and abort the exact reconciliation it exists to do.
+            // Treat a missing directory as simply absent from disk so it still
+            // surfaces as a `dropped` manifest entry instead of crashing gc().
+            if (err.code === 'ENOENT')
+                continue;
+            throw err;
+        }
         const rel = path.relative(rootReal, absReal).split(path.sep).join('/');
         paths.push(rel);
     }

--- a/tools/loop-worktree/src/worktree.ts
+++ b/tools/loop-worktree/src/worktree.ts
@@ -279,7 +279,20 @@ async function gitWorktreePaths(root: string): Promise<string[]> {
   for (const line of out.split('\n')) {
     if (!line.startsWith('worktree ')) continue;
     const abs = line.slice('worktree '.length).trim();
-    const absReal = await realpath(abs);
+    let absReal: string;
+    try {
+      absReal = await realpath(abs);
+    } catch (err) {
+      // git keeps listing a worktree (as "prunable") even after its directory
+      // was removed out-of-band -- a manual `rm -rf`, a crash mid-cleanup, a
+      // container wipe -- rather than via `git worktree remove`. realpath()
+      // on that now-missing path throws ENOENT, which used to propagate out
+      // of gc() entirely and abort the exact reconciliation it exists to do.
+      // Treat a missing directory as simply absent from disk so it still
+      // surfaces as a `dropped` manifest entry instead of crashing gc().
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
     const rel = path.relative(rootReal, absReal).split(path.sep).join('/');
     paths.push(rel);
   }

--- a/tools/loop-worktree/test/worktree.test.mjs
+++ b/tools/loop-worktree/test/worktree.test.mjs
@@ -167,6 +167,24 @@ test('gc drops manifest entries whose worktree was removed out of band', async (
   }
 });
 
+test('gc does not crash when a worktree directory was deleted without git worktree remove', async () => {
+  const dir = await initRepo();
+  try {
+    await createWorktree({ root: dir, runId: 'wiped', pattern: 'ci-sweeper' });
+    // Simulate a manual `rm -rf` / crash mid-cleanup / container wipe: the
+    // directory is gone but git still lists it (as "prunable") since it was
+    // never told via `git worktree remove`.
+    await rm(path.join(dir, '.loop-worktrees', 'wiped'), { recursive: true, force: true });
+
+    const result = await gc({ root: dir });
+    assert.deepEqual(result.dropped.map((e) => e.id), ['wiped']);
+    const manifest = await readManifest(dir);
+    assert.equal(manifest.worktrees.length, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('cleanup honors --older-than', async () => {
   const dir = await initRepo();
   try {


### PR DESCRIPTION
## Problem
gc()'s gitWorktreePaths() calls realpath() on every path reported by
`git worktree list --porcelain` with no error handling. git keeps
listing a worktree (annotated "prunable") even after its directory is
gone -- a manual rm -rf, a crash mid-cleanup, a container wipe --
rather than removed via `git worktree remove`. realpath() on that
now-missing path throws ENOENT, which propagated out of gc() entirely
instead of surfacing the entry as `dropped`, aborting the exact
reconciliation gc() exists to perform.

## Fix
Treat a missing directory as simply absent from disk instead of
letting the exception escape. The manifest entry (if any) is now
correctly reconciled as `dropped`.

## Test plan
Added a regression test that deletes a worktree directory directly
(bypassing `git worktree remove`) and asserts gc() completes and
reports it as dropped. Full clean rebuild + npm test: 36/36 passing.