### PR TITLE
fix(scripts): stop pruning run-log entries with non-ISO run_id

### DIFF
--- a/scripts/append-run-log.mjs
+++ b/scripts/append-run-log.mjs
@@ -7,6 +7,15 @@ import { readFile, writeFile } from 'node:fs/promises';
 
 const MARKER = '<!-- Loop appends below this line -->';
 const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+// Only strings shaped like an ISO date are treated as timestamps for pruning.
+// `new Date(...)` is a lenient parser: a non-ISO run_id (a numeric GitHub run
+// id, a custom slug like "run-1") doesn't reliably yield NaN, it can parse
+// into a spurious in-range-looking date instead (e.g. "run-1" -> 2001-01-01),
+// which would then read as "older than 30 days" and get silently pruned even
+// though the entry was just written. Gate the parse on this pattern first so
+// non-ISO run_ids are always kept, matching loop-metrics' handling of the
+// same run_id shapes.
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}/;
 
 const entryJson = process.argv[2];
 const logPath = process.argv[3] || 'loop-run-log.md';
@@ -40,8 +49,8 @@ for (const line of after.split('\n')) {
   if (!trimmed.startsWith('{')) continue;
   try {
     const obj = JSON.parse(trimmed);
-    const t = new Date(obj.run_id).getTime();
-    if (!Number.isNaN(t) && now - t <= MAX_AGE_MS) {
+    const t = ISO_DATE_RE.test(obj.run_id) ? new Date(obj.run_id).getTime() : NaN;
+    if (Number.isNaN(t) || now - t <= MAX_AGE_MS) {
       kept.push(trimmed);
     }
   } catch {

--- a/scripts/append-run-log.test.mjs
+++ b/scripts/append-run-log.test.mjs
@@ -10,9 +10,15 @@ import { promisify } from 'node:util';
 import { mkdtemp, writeFile, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const exec = promisify(execFile);
-const SCRIPT = new URL('./append-run-log.mjs', import.meta.url).pathname;
+// `new URL(...).pathname` yields a leading-slash path (e.g. "/D:/...") that
+// Windows' node CLI mis-resolves relative to the current drive instead of
+// treating as absolute (same class of bug already fixed for
+// tools/loop/test/files.test.mjs) -- fileURLToPath() gives the correct
+// platform-native path on every OS.
+const SCRIPT = fileURLToPath(new URL('./append-run-log.mjs', import.meta.url));
 
 test('invalid JSON second arg exits 1 with a Usage / valid JSON message', async () => {
   await assert.rejects(
@@ -36,6 +42,23 @@ test('valid minimal JSON entry does not throw on parse', async () => {
     assert.match(stdout, /Appended run run-1/);
     const written = await readFile(logPath, 'utf8');
     assert.ok(written.includes('"run_id":"run-1"'));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a non-ISO run_id (e.g. a custom slug) survives the next append instead of being pruned', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'append-run-log-'));
+  const logPath = path.join(dir, 'loop-run-log.md');
+  await writeFile(logPath, '<!-- Loop appends below this line -->\n');
+  try {
+    // "run-1" parses under JS's lenient Date constructor into 2001-01-01,
+    // which looks 30+ days old -- it must not be pruned on the next append.
+    await exec('node', [SCRIPT, JSON.stringify({ run_id: 'run-1', outcome: 'ok' }), logPath]);
+    await exec('node', [SCRIPT, JSON.stringify({ run_id: 'run-2', outcome: 'ok' }), logPath]);
+    const written = await readFile(logPath, 'utf8');
+    assert.ok(written.includes('"run_id":"run-1"'), 'run-1 entry should still be present');
+    assert.ok(written.includes('"run_id":"run-2"'), 'run-2 entry should still be present');
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem
scripts/append-run-log.mjs prunes entries older than 30 days using
new Date(obj.run_id).getTime(). JS's Date constructor is lenient: a
non-ISO run_id (a numeric GitHub run id, a custom slug like "run-1")
doesn't reliably parse to NaN -- it can parse into a spurious
in-range-looking date instead ("run-1" -> 2001-01-01), which then
reads as 30+ days old and gets silently deleted on the very next
append, even though the entry was just written. tools/loop-metrics
already handles this exact run_id shape correctly (keep on
unparseable rather than drop); this script did the opposite.

## Fix
Only strings shaped like an ISO date (^\d{4}-\d{2}-\d{2}) are parsed
as timestamps for pruning at all; anything else is always kept,
matching loop-metrics' handling.

Also fixes append-run-log.test.mjs's own SCRIPT path, which used
new URL(...).pathname -- on Windows that yields a leading-slash path
("/D:/...") that node's CLI mis-resolves relative to the current
drive instead of as absolute (the same class of bug already fixed for
tools/loop/test/files.test.mjs in #502). Switched to fileURLToPath().

## Test plan
Added a regression test appending an entry with a non-ISO run_id
("run-1") followed by a second append, asserting the first entry
survives. node --test scripts/append-run-log.test.mjs: 3/3 passing
(this also required the Windows path fix to even run locally).