### PR TITLE
fix(loop-context): don't crash when an --on-exceed hook ignores stdin

### DIFF
--- a/tools/loop-context/dist/cli.js
+++ b/tools/loop-context/dist/cli.js
@@ -276,6 +276,14 @@ function runOnExceedHook(script, decision) {
             resolve();
         });
         child.on('close', () => resolve());
+        // The hook script may exit without ever reading stdin (e.g. a notify
+        // script that ignores its input). Writing to that already-closed pipe
+        // then raises an 'error' event (EPIPE on POSIX, EOF on Windows) on the
+        // stream itself; left unhandled, Node treats that as an uncaught
+        // exception and crashes the whole process. This hook is documented as
+        // fire-and-forget, so a write failure here must not escalate past the
+        // 'close' handler above, which resolves regardless.
+        child.stdin.on('error', () => { });
         child.stdin.write(JSON.stringify(decision));
         child.stdin.end();
     });

--- a/tools/loop-context/src/cli.ts
+++ b/tools/loop-context/src/cli.ts
@@ -302,6 +302,14 @@ function runOnExceedHook(script: string, decision: BreakerDecision): Promise<voi
       resolve();
     });
     child.on('close', () => resolve());
+    // The hook script may exit without ever reading stdin (e.g. a notify
+    // script that ignores its input). Writing to that already-closed pipe
+    // then raises an 'error' event (EPIPE on POSIX, EOF on Windows) on the
+    // stream itself; left unhandled, Node treats that as an uncaught
+    // exception and crashes the whole process. This hook is documented as
+    // fire-and-forget, so a write failure here must not escalate past the
+    // 'close' handler above, which resolves regardless.
+    child.stdin.on('error', () => {});
     child.stdin.write(JSON.stringify(decision));
     child.stdin.end();
   });

--- a/tools/loop-context/test/cli.test.mjs
+++ b/tools/loop-context/test/cli.test.mjs
@@ -10,6 +10,7 @@ import { resolveDailyBudgetFromPattern } from '../dist/budget-resolver.js';
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const cli = path.join(testDir, '../dist/cli.js');
 const onExceedCaptureScript = path.join(testDir, 'fixtures/on-exceed-capture.mjs');
+const onExceedIgnoreStdinScript = path.join(testDir, 'fixtures/on-exceed-ignore-stdin.mjs');
 
 async function freshDir() {
   return mkdtemp(path.join(tmpdir(), 'loop-context-cli-daily-'));
@@ -28,6 +29,9 @@ function runCli(args, input = stagnationLedger) {
   return spawnSync(process.execPath, [cli, ...args], {
     input,
     encoding: 'utf8',
+    // Default 1MB is too small once a decision's JSON echoes back a large
+    // error string (see the --on-exceed EPIPE regression test below).
+    maxBuffer: 20 * 1024 * 1024,
   });
 }
 
@@ -153,4 +157,32 @@ test('cli --on-exceed is not invoked when the run continues', async () => {
   );
   assert.equal(r.status, 0);
   await assert.rejects(() => readFile(outFile, 'utf8'));
+});
+
+test('cli --on-exceed does not crash when the hook script exits without reading stdin', async () => {
+  const dir = await freshDir();
+  const outFile = path.join(dir, 'ran.marker');
+
+  // A large first-line error survives errorSignature() unshortened, so the
+  // piped decision JSON is big enough to exceed the OS pipe buffer -- this
+  // makes the write-after-close failure (EPIPE on POSIX, EOF on Windows)
+  // land reliably instead of racing the hook process's own startup time.
+  const bigError = 'e'.repeat(5_000_000);
+  const bigLedger = JSON.stringify({
+    goal: 'x',
+    attempts: [
+      { iteration: 1, action: 'a', outcome: 'failure', error: bigError },
+      { iteration: 2, action: 'a', outcome: 'failure', error: bigError },
+      { iteration: 3, action: 'a', outcome: 'failure', error: bigError },
+    ],
+  });
+
+  const r = runCli(
+    ['--check', '--on-exceed', `node ${onExceedIgnoreStdinScript} ${outFile}`, '--json'],
+    bigLedger,
+  );
+
+  assert.equal(r.status, 2, `expected a clean escalation exit, not a crash. stderr: ${r.stderr}`);
+  assert.doesNotMatch(r.stderr, /Uncaught|EPIPE|EOF/);
+  assert.equal(await readFile(outFile, 'utf8'), 'ran');
 });

--- a/tools/loop-context/test/fixtures/on-exceed-ignore-stdin.mjs
+++ b/tools/loop-context/test/fixtures/on-exceed-ignore-stdin.mjs
@@ -1,0 +1,6 @@
+import { writeFileSync } from 'node:fs';
+
+// Deliberately never reads stdin -- simulates an operator's notify script
+// that ignores its input entirely. Writes a marker first so the test can
+// confirm this process actually ran despite draining nothing.
+writeFileSync(process.argv[2], 'ran');


### PR DESCRIPTION
## Problem
runOnExceedHook() piped the escalation decision to the hook script's
stdin with no 'error' listener on the stream itself. If the script
exits without ever reading stdin -- a completely ordinary shape for a
notify script (e.g. one that just does `echo escalated`) -- writing to
that already-closed pipe raises an 'error' event on the stream (EPIPE
on POSIX, EOF on Windows). Node treats an unhandled stream 'error' as
an uncaught exception by default, crashing the whole loop-context
process, even though this hook is documented and coded as
fire-and-forget: the crash happens after the circuit breaker has
already made its decision, so it turns a successful --check run into
a hard failure for a reason entirely unrelated to the ledger.

## Fix
Attach a no-op 'error' listener on child.stdin so a write-after-close
failure is absorbed instead of escalating past the 'close' handler,
which already resolves the promise regardless of how the hook exited.

## Test plan
Added a regression test with a hook script that never reads stdin,
using a large ledger error string so the piped decision JSON reliably
exceeds the OS pipe buffer (removing timing flakiness from the repro)
-- confirmed it fails with the exact "write EOF" crash against the
pre-fix code and passes with the fix. Full clean rebuild + npm test:
52/52 passing.