### PR TITLE
fix(loop-cost): reject zero cadence intervals

### DIFF
--- a/tools/loop-cost/dist/estimator.js
+++ b/tools/loop-cost/dist/estimator.js
@@ -47,7 +47,11 @@ export function parseInterval(token) {
     if (!m)
         throw new Error(`Invalid cadence interval: ${token}`);
     const unit = m[2];
-    return Number(m[1]) * INTERVAL_MS[unit];
+    const value = Number(m[1]);
+    if (value <= 0) {
+        throw new Error(`Invalid cadence interval: ${token}. The interval value must be greater than zero.`);
+    }
+    return value * INTERVAL_MS[unit];
 }
 /** Runs per day for a single interval like 15m or 1d. */
 export function runsPerDayForInterval(interval) {

--- a/tools/loop-cost/src/estimator.ts
+++ b/tools/loop-cost/src/estimator.ts
@@ -113,7 +113,11 @@ export function parseInterval(token: string): number {
   const m = token.match(/^(\d+)([mhd])$/);
   if (!m) throw new Error(`Invalid cadence interval: ${token}`);
   const unit = m[2] as keyof typeof INTERVAL_MS;
-  return Number(m[1]) * INTERVAL_MS[unit];
+  const value = Number(m[1]);
+  if (value <= 0) {
+    throw new Error(`Invalid cadence interval: ${token}. The interval value must be greater than zero.`);
+  }
+  return value * INTERVAL_MS[unit];
 }
 
 /** Runs per day for a single interval like 15m or 1d. */

--- a/tools/loop-cost/test/estimator.test.mjs
+++ b/tools/loop-cost/test/estimator.test.mjs
@@ -30,6 +30,10 @@ test('runsPerDayForInterval: 1d = 1', () => {
   assert.equal(runsPerDayForInterval('1d'), 1);
 });
 
+test('runsPerDayForInterval rejects a zero cadence', () => {
+  assert.throws(() => runsPerDayForInterval('0m'), /greater than zero/);
+});
+
 test('cadenceToRunsPerDay: range uses fastest by default', () => {
   assert.equal(cadenceToRunsPerDay('5m-15m'), 288);
 });


### PR DESCRIPTION
## Summary

Reject zero-length cadence intervals so `loop-cost` fails clearly instead of emitting `Infinity` runs/day and `null` JSON estimates.

The parser previously accepted `0m` as zero milliseconds, which made the runs-per-day calculation divide by zero.

## Related issue

No existing issue or pull request matched the exact `0m` symptom or the affected `parseInterval` path.

## Changes

- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example / story improvement
- [x] Tool / CLI change under `tools/`
- [ ] Test only
- [ ] Other

- Validate that a parsed cadence is greater than zero before converting it to milliseconds.
- Add a regression test that rejects `0m`.
- Keep the repository-tracked `dist` runtime synchronized with the TypeScript source.

## Checklist (from CONTRIBUTING)

- [x] Links work from README or the relevant index (no links changed)
- [x] No secrets, tokens, or internal company URLs
- [x] `STATE.md*` examples use `.example` suffix (no state examples changed)
- [x] Safety-related content references `docs/safety.md` (no safety content changed)
- [x] If you touched a package under `tools/<pkg>`: `cd tools/<pkg> && npm ci && npm test`
- [x] If you touched the registry: root `npm ci && npm run validate:registry` (registry not changed; the repository validation gate passed)

## Testing / Dogfood

- [x] `cd tools/loop-cost && npm test` — 13 tests passed
- [x] `bash scripts/ci-validate-gates.sh`
- [x] `bash scripts/ci-audit-gates.sh`
- [x] Manual review of generated state / skill output if scaffolding changed (no scaffolding changed)

## Regression evidence

- Before: `cd tools/loop-cost && npm test` exited `1` because the new test did not observe an exception.
- After: `cd tools/loop-cost && npm test` exited `0`.
- CLI behavior after the fix: `--cadence 0m` exits `1` with `The interval value must be greater than zero.`

## Scope

- 3 files changed, +14 / -2 lines

---

Docs, stories, adopters, and small tests: **maintainers aim to review within 48 hours** (same-day when possible).
