### PR TITLE
fix(mcp-server): stop mislabeling every estimateCost failure as an invalid cadence

### DIFF
--- a/tools/mcp-server/dist/index.js
+++ b/tools/mcp-server/dist/index.js
@@ -284,8 +284,15 @@ server.tool('loop_estimate_cost', 'Estimate daily token cost for a pattern at a 
     try {
         result = estimateCost({ pattern, level, cadence });
     }
-    catch {
-        return { content: [{ type: 'text', text: `Invalid cadence: ${cadence ?? pattern.cadence}` }] };
+    catch (err) {
+        // estimateCost() can fail for reasons that have nothing to do with
+        // cadence -- e.g. a registry.yaml entry with a missing/malformed
+        // `cost` block throws a TypeError reading its fields. Hardcoding
+        // "Invalid cadence" here regardless of the actual failure misled
+        // whoever was debugging a broken registry entry. Surface the real
+        // message instead.
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: 'text', text: `Cost estimate failed: ${message}` }] };
     }
     const fmt = (n) => n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1_000 ? `${Math.round(n / 1_000)}k` : String(n);
     const { scenarios, suggestedDailyCap } = result;

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -402,8 +402,15 @@ server.tool(
     let result;
     try {
       result = estimateCost({ pattern, level, cadence });
-    } catch {
-      return { content: [{ type: 'text' as const, text: `Invalid cadence: ${cadence ?? pattern.cadence}` }] };
+    } catch (err) {
+      // estimateCost() can fail for reasons that have nothing to do with
+      // cadence -- e.g. a registry.yaml entry with a missing/malformed
+      // `cost` block throws a TypeError reading its fields. Hardcoding
+      // "Invalid cadence" here regardless of the actual failure misled
+      // whoever was debugging a broken registry entry. Surface the real
+      // message instead.
+      const message = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: 'text' as const, text: `Cost estimate failed: ${message}` }] };
     }
 
     const fmt = (n: number) => n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1_000 ? `${Math.round(n / 1_000)}k` : String(n);

--- a/tools/mcp-server/test/server.test.mjs
+++ b/tools/mcp-server/test/server.test.mjs
@@ -460,6 +460,59 @@ test('loop_estimate_cost accounts for early_exit_required instead of a flat mix'
   }
 });
 
+test('loop_estimate_cost surfaces the real error for a bad cadence override', async () => {
+  const root = await setup();
+  try {
+    const res = await callServer(root, [{
+      id: 1, method: 'tools/call',
+      params: { name: 'loop_estimate_cost', arguments: { patternId: 'daily-triage', level: 'L2', cadence: 'not-a-cadence' } },
+    }]);
+    const text = res.get(1).result.content[0].text;
+    // Propagates loop-cost's own message (e.g. "Invalid cadence interval:
+    // not") instead of a hardcoded guess.
+    assert.match(text, /Invalid cadence/i);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('loop_estimate_cost does not mislabel a broken registry entry as an invalid cadence', async () => {
+  // A pattern missing its `cost` block throws a TypeError inside
+  // estimateCost() that has nothing to do with cadence -- the catch-all
+  // used to always report "Invalid cadence" regardless of the real cause.
+  const brokenRoot = await mkdtemp(path.join(tmpdir(), 'mcp-test-broken-registry-'));
+  try {
+    await mkdir(path.join(brokenRoot, 'patterns'), { recursive: true });
+    await writeFile(
+      path.join(brokenRoot, 'patterns', 'registry.yaml'),
+      `patterns:
+  - id: no-cost-block
+    name: No Cost Block
+    file: no-cost-block.md
+    goal: Missing its cost block
+    cadence: 1d
+    risk: low
+    tools: [grok]
+    skills: []
+    state: STATE.md
+    phases: [report]
+    human_gates: []
+    starter: starters/minimal-loop
+    week_one_mode: L1
+    token_cost: low
+`,
+    );
+    const res = await callServer(brokenRoot, [{
+      id: 1, method: 'tools/call',
+      params: { name: 'loop_estimate_cost', arguments: { patternId: 'no-cost-block', level: 'L2' } },
+    }]);
+    const text = res.get(1).result.content[0].text;
+    assert.ok(!text.includes('Invalid cadence'), `should not blame cadence for a missing cost block: ${text}`);
+  } finally {
+    await rm(brokenRoot, { recursive: true, force: true });
+  }
+});
+
 test('pattern resource is readable over stdio', async () => {
   const root = await setup();
   try {


### PR DESCRIPTION
## Problem
The loop_estimate_cost tool's catch-all around estimateCost() always
reported "Invalid cadence: <value>" regardless of what actually threw.
estimateCost() can fail for reasons that have nothing to do with
cadence -- e.g. a registry.yaml pattern entry with a missing or
malformed `cost` block throws a TypeError reading its fields. Anyone
debugging a broken registry entry got pointed at the wrong cause
entirely.

## Fix
Surface the real thrown message instead of guessing.

## Test plan
Two new tests -- one confirms a genuinely bad cadence override still
reports loop-cost's own "Invalid cadence" message (not a hardcoded
guess), the other adds a pattern missing its `cost` block and asserts
the resulting error does not claim the cadence is invalid. Confirmed
the second one fails with the old catch-all ("Invalid cadence: 1d" for
a perfectly valid cadence) and passes with the fix. Full clean rebuild
+ npm test: 28/28 passing.