### PR TITLE
fix(docs): URL-encode owner/repo before hitting the GitHub API in star-history

### DIFF
--- a/docs/star-history.html
+++ b/docs/star-history.html
@@ -234,7 +234,7 @@ title: Star History — Loop Engineering
     const timestamps = [];
     let page = 1;
     while (true) {
-      const url = `https://api.github.com/repos/${owner}/${repo}/stargazers?per_page=100&page=${page}`;
+      const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/stargazers?per_page=100&page=${page}`;
       const res = await fetch(url, {
         headers: {
           Accept: 'application/vnd.github.v3.star+json',


### PR DESCRIPTION
## Problem
fetchStarTimestamps() interpolated owner/repo straight into the
stargazers request URL with no encoding. parseRepos() takes raw
user-typed text, so a repo string containing a space, &, #, or other
URL-significant character (a stray character when pasting, or a
free-form "owner/repo name" typo) silently broke the query string or
truncated the path instead of producing a clean request or a readable
404.

## Fix
Wrap both segments in encodeURIComponent(). Verified normal repo
names (e.g. cobusgreyling/loop-engineering) produce an identical URL,
and a name with a space and an ampersand now encodes cleanly instead
of corrupting the query string.