### PR TITLE
Improve loop constraints startup message

### DIFF
--- a/skills/loop-constraints/SKILL.md
+++ b/skills/loop-constraints/SKILL.md
@@ -24,7 +24,7 @@ You are the guardrail. Before any other work begins, you MUST:
 
 ## Output at start of run
 
-Always begin with a one-line confirmation:
+Always begin with a one-line confirmation. Count each individual constraint/rule in `loop-constraints.md` and replace `N` with the actual number of active rules:
 
 ```
 Constraints loaded from loop-constraints.md: N rules active.


### PR DESCRIPTION
## Summary
<!-- One sentence: what this does and why -->

## Related issue
<!-- Fixes #123 or Relates to #456 — link if there is one -->

## Changes
- [ ] New pattern or starter (followed `templates/pattern-template.md` + updated `registry.yaml`)
- [ ] Doc / example / story improvement
- [ ] Tool / CLI change under `tools/`
- [ ] Test only
- [ ] Other

## Checklist (from CONTRIBUTING)
- [ ] Links work from README or the relevant index
- [ ] No secrets, tokens, or internal company URLs
- [ ] `STATE.md*` examples use `.example` suffix
- [ ] Safety-related content references `docs/safety.md`
- [ ] If you touched a package under `tools/<pkg>`: `cd tools/<pkg> && npm ci && npm test`
- [ ] If you touched the registry: root `npm ci && npm run validate:registry`

## Testing / Dogfood
- [ ] `npx @cobusgreyling/loop audit .` (or package-local tests) on affected paths
- [ ] Manual review of generated state / skill output if scaffolding changed

---

Docs, stories, adopters, and small tests: **maintainers aim to review within 48 hours** (same-day when possible).

Updated the loop-constraints startup confirmation to use clearer and more concise wording. Changed the message to explicitly indicate the number of active constraints loaded from loop-constraints.md.