### PR TITLE
fix(loop-init): pin loop-audit to published ^1.7.0

### DIFF
--- a/tools/loop-init/package.json
+++ b/tools/loop-init/package.json
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@cobusgreyling/loop-audit": "^1.8.0"
+    "@cobusgreyling/loop-audit": "^1.7.0"
   },
   "devDependencies": {
     "@types/node": "^26.0.0",


### PR DESCRIPTION
Weekly Dependabot Updates for `/tools/loop-init` have been failing (`updater encountered one or more errors`).

`tools/loop-init/package.json` declared `@cobusgreyling/loop-audit: ^1.8.0`, but npm latest is still **1.7.0**. `tools/loop-audit` on main is already 1.8.0 in git, unpublished. The lockfile still resolved 1.7.0, so Dependabot could not satisfy the range.

This pins the range back to `^1.7.0` (matches npm + lockfile). Re-bump after `loop-audit@1.8.0` is published. No lockfile change needed.