### PR TITLE
fix(ci): npm publish via NPM_TOKEN

### DIFF
--- a/.github/workflows/release-loop-audit.yml
+++ b/.github/workflows/release-loop-audit.yml
@@ -56,5 +56,5 @@ jobs:
           "
           npm publish --access public --provenance
         env:
-          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-init.yml
+++ b/.github/workflows/release-loop-init.yml
@@ -53,5 +53,5 @@ jobs:
           # package.json keeps registry range (^1.x) for the published tarball
           npm publish --access public --provenance
         env:
-          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop.yml
+++ b/.github/workflows/release-loop.yml
@@ -51,5 +51,6 @@ jobs:
         working-directory: tools/loop
         run: npm publish --access public --provenance
         env:
-          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
+          # Trusted publisher OIDC 404'd (npm GAT). Fall back to repo NPM_TOKEN.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
OIDC trusted publishing 404'd on PUT for loop-v0.2.0, loop-init-v1.7.0, loop-audit-v1.9.0. This restores NODE_AUTH_TOKEN from the repo NPM_TOKEN secret so we can re-run those release workflows from main.