### PR TITLE
fix(ci): OIDC publish without NPM_TOKEN

### DIFF
--- a/.github/workflows/release-loop-audit.yml
+++ b/.github/workflows/release-loop-audit.yml
@@ -56,5 +56,5 @@ jobs:
           "
           npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
           NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop-init.yml
+++ b/.github/workflows/release-loop-init.yml
@@ -53,5 +53,5 @@ jobs:
           # package.json keeps registry range (^1.x) for the published tarball
           npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
           NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release-loop.yml
+++ b/.github/workflows/release-loop.yml
@@ -51,6 +51,5 @@ jobs:
         working-directory: tools/loop
         run: npm publish --access public --provenance
         env:
-          # Trusted publisher OIDC 404'd (npm GAT). Fall back to repo NPM_TOKEN.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing — do not set NODE_AUTH_TOKEN (it overrides OIDC)
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
Retry path for loop 0.2.0 / loop-init 1.7.0 / loop-audit 1.9.0. Trusted publisher OIDC cannot run while NODE_AUTH_TOKEN is set.