### PR TITLE
docs: restore the iconic LE5 README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 
 > **Stop prompting. Design the loop. Get a score.**
 
+<p align="center">
+  <img src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/LE5.jpeg" alt="Loop Engineering — design the system that prompts your agents" width="100%" />
+</p>
+
 <p align="center"><strong>Start in 5 minutes</strong> ·
   <a href="docs/QUICKSTART.md">Quickstart</a> ·
   <a href="docs/jobs.md">What do you want to do?</a> ·

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,6 +2,10 @@
 
 > **别再逐条提示。设计循环。拿一个分数。**
 
+<p align="center">
+  <img src="https://cdn.jsdelivr.net/gh/cobusgreyling/loop-engineering@main/assets/visuals/LE5.jpeg" alt="Loop Engineering — 设计会提示你的 agent 的系统" width="100%" />
+</p>
+
 [English README](README.md) · [5 分钟快速开始](docs/QUICKSTART.md) · [我想重构项目](docs/refactor.md)
 
 ```bash


### PR DESCRIPTION
Puts `assets/visuals/LE5.jpeg` back on the English and Chinese READMEs, under the tagline. README stays short.