### PR TITLE
docs: add QA API Automation as adopter

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -38,6 +38,7 @@ Or open a PR that adds a row to the table below:
 | [loop-engineering](https://github.com/cobusgreyling/loop-engineering) (maintainer) | PR Babysitter, Dependency Sweeper | Grok / Claude Code | L2 | Assisted fixes in worktrees; human gate on merges; patch-only deps |
 | [Hermes Agent](https://github.com/NousResearch/hermes-agent) by [Nous Research](https://nousresearch.com) | Daily Triage | Hermes | L1 | Six loop primitives in one binary — `hermes cron` + skill + `delegate_task` + MCP + memory. Reference: [examples/hermes/daily-triage.md](../examples/hermes/daily-triage.md) |
 | [Pluribus](https://github.com/caioribeiroclw-pixel/pluribus) | Daily Triage, Issue Triage | Mixed (OpenClaw) | L2 | Hourly market/adoption research loop; durable state in control plane; cross-tool privacy-safe receipts needed |
+| [QA API Automation](https://github.com/Ayush02jain/qa-api-automation) | CI Sweeper | GitHub Actions | L1 | Report-only CI failure detection for the API Automation Tests workflow |
 
 *Your project here — see [CONTRIBUTING.md](../CONTRIBUTING.md).*
 


### PR DESCRIPTION
Adds QA API Automation to the Loop Engineering adopters list.

The project uses the CI Sweeper pattern at L1 with GitHub Actions.
The workflow is report-only and detects failures from the API Automation Tests workflow.

Closes #120