### PR TITLE
feat(loop-init): add orcarouter model provider

### DIFF
--- a/tools/loop-init/README.md
+++ b/tools/loop-init/README.md
@@ -40,20 +40,22 @@ Every `loop-init` run prints a Foundry CTA; when Loop Ready is **≥ 80**, the C
 
 ### Interface provider (implementer preset)
 
-The `implementer` preset defaults to the built-in interface primitive. Pass `--model-provider minimax` to emit a `model/minimax` provider primitive instead. The generated stack always carries both regional endpoints and both model options, so you can switch region/model without regenerating:
+The `implementer` preset defaults to the built-in interface primitive. Pass `--model-provider minimax` to emit a `model/minimax` provider primitive instead, or `--model-provider orcarouter` to emit a `model/orcarouter` provider primitive. The generated stack always carries the provider endpoints and model options, so you can switch provider/model without regenerating:
 
 ```bash
 npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax
 npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax --region cn_zh --model MiniMax-M2.7
+npx @cobusgreyling/loop-init . -p ci-sweeper -t claude --with-foundry --model-provider orcarouter
+npx @cobusgreyling/loop-init . -p ci-sweeper -t claude --with-foundry --model-provider orcarouter --model orcarouter/auto
 ```
 
 | Flag | Values | Default |
 |------|--------|---------|
-| `--model-provider` | `anthropic`, `minimax` | `anthropic` |
+| `--model-provider` | `anthropic`, `minimax`, `orcarouter` | `anthropic` |
 | `--region` | `global_en`, `cn_zh` | `global_en` |
-| `--model` | `MiniMax-M3`, `MiniMax-M2.7` | `MiniMax-M3` |
+| `--model` | `MiniMax-M3`, `MiniMax-M2.7`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/auto`, `orcarouter/free` | `MiniMax-M3` / `orcarouter/fusion` |
 
-MiniMax model options and both endpoints (`global_en` → `https://api.minimax.io`, `cn_zh` → `https://api.minimaxi.com`) are written into `.foundry/stack.yaml`.
+MiniMax model options and both endpoints (`global_en` → `https://api.minimax.io`, `cn_zh` → `https://api.minimaxi.com`) are written into `.foundry/stack.yaml`. The OrcaRouter provider writes the gateway's OpenAI- and Anthropic-compatible endpoints (`https://api.orcarouter.ai`) plus its routing model options (`orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/auto`, `orcarouter/free`).
 
 ## Patterns
 

--- a/tools/loop-init/dist/cli.js
+++ b/tools/loop-init/dist/cli.js
@@ -106,6 +106,60 @@ const MINIMAX_REGIONS = [
 ];
 const MINIMAX_MODEL_IDS = MINIMAX_MODELS.map((m) => m.id);
 const MINIMAX_REGION_IDS = MINIMAX_REGIONS.map((r) => r.region);
+const ORCAROUTER_DEFAULT_MODEL = 'orcarouter/fusion';
+const ORCAROUTER_BASE_URL = 'https://api.orcarouter.ai';
+const ORCAROUTER_MODELS = [
+    {
+        id: 'orcarouter/fusion',
+        contextWindow: 1_000_000,
+        thinking: ['adaptive', 'disabled'],
+        notes: 'Adaptive-routing flagship; multi-model aggregate with automatic failover',
+    },
+    {
+        id: 'orcarouter/fusion-flash',
+        contextWindow: 200_000,
+        thinking: ['adaptive', 'disabled'],
+        notes: 'Fast adaptive-routing tier for high-volume, latency-sensitive loops',
+    },
+    {
+        id: 'orcarouter/auto',
+        contextWindow: 1_000_000,
+        thinking: ['adaptive', 'disabled'],
+        notes: 'Cost-optimized routing tier',
+    },
+    {
+        id: 'orcarouter/free',
+        contextWindow: 200_000,
+        thinking: ['disabled'],
+        notes: 'Zero-cost tier for report-only loops',
+    },
+];
+const ORCAROUTER_MODEL_IDS = ORCAROUTER_MODELS.map((m) => m.id);
+/**
+ * Render the `model/orcarouter` interface primitive for the implementer stack.
+ * OrcaRouter exposes an OpenAI-compatible gateway that routes a single model
+ * id across many upstream models. Both protocol shapes live on the same
+ * gateway base URL — the OpenAI and Anthropic-compatible paths are identical
+ * and the client picks the wire format via its request headers.
+ */
+function orcarouterInterfaceYaml(model) {
+    const models = ORCAROUTER_MODELS.map((m) => [
+        `          - id: ${m.id}`,
+        `            context_window: ${m.contextWindow}`,
+        `            thinking: [${m.thinking.join(', ')}]`,
+        `            notes: "${m.notes}"`,
+    ].join('\n')).join('\n');
+    return `    - primitive: model/orcarouter
+      config:
+        model: ${model}
+        models:
+${models}
+        endpoints:
+          global:
+            openai_base_url: ${ORCAROUTER_BASE_URL}/v1
+            anthropic_base_url: ${ORCAROUTER_BASE_URL}/v1
+            docs_root: https://www.orcarouter.ai`;
+}
 /** Render the `model/minimax` interface primitive for the implementer stack. */
 function minimaxInterfaceYaml(model, region) {
     const models = MINIMAX_MODELS.map((m) => [
@@ -176,7 +230,9 @@ function foundryStackYaml(stackName, pattern, preset, provider = 'anthropic', re
     if (preset === 'implementer') {
         const interfaceLayer = provider === 'minimax'
             ? minimaxInterfaceYaml(model, region)
-            : `    - primitive: model/anthropic
+            : provider === 'orcarouter'
+                ? orcarouterInterfaceYaml(model)
+                : `    - primitive: model/anthropic
       config:
         model: claude-sonnet-4-6`;
         return `name: ${stackName}
@@ -660,9 +716,9 @@ Options:
   --with-foundry    Also scaffold .foundry/ stack (harness-foundry runtime)
   --with-memory     Also scaffold memory-engineering tiers and budget
   --with-fleet      Also scaffold fleet-engineering registry and inbox
-  --model-provider  Implementer interface provider (default: anthropic; minimax)
+  --model-provider  Implementer interface provider (default: anthropic; minimax, orcarouter)
   --region          MiniMax region when --model-provider minimax (global_en, cn_zh)
-  --model           MiniMax model when --model-provider minimax (MiniMax-M3, MiniMax-M2.7)
+  --model           Provider model when --model-provider minimax/orcarouter (default: MiniMax-M3 / orcarouter/fusion)
   --dry-run         Print actions without copying
   -h, --help        This help
 
@@ -677,13 +733,14 @@ Examples:
   npx @cobusgreyling/loop-init . -p pr-babysitter -t claude --with-foundry
   npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax
   npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax --region cn_zh --model MiniMax-M2.7
+  npx @cobusgreyling/loop-init . -p ci-sweeper -t claude --with-foundry --model-provider orcarouter --model orcarouter/auto
   npx @cobusgreyling/loop-init . -p daily-triage -t opencode
   npx @cobusgreyling/loop-init . --with-memory
   npx @cobusgreyling/loop-init . --with-fleet
 `);
         process.exit(0);
     }
-    const { pattern, tool, target, dryRun, withFoundry, withMemory, withFleet, modelProvider, region, model } = args;
+    let { pattern, tool, target, dryRun, withFoundry, withMemory, withFleet, modelProvider, region, model } = args;
     const validPatterns = Object.keys(PATTERN_STARTERS);
     const validTools = Object.keys(TOOL_SUFFIX);
     if (!validPatterns.includes(pattern)) {
@@ -694,7 +751,7 @@ Examples:
         console.error(`Unknown tool: ${tool}. Valid: ${validTools.join(', ')}`);
         process.exit(1);
     }
-    const validProviders = ['anthropic', 'minimax'];
+    const validProviders = ['anthropic', 'minimax', 'orcarouter'];
     if (!validProviders.includes(modelProvider)) {
         console.error(`Unknown model provider: ${modelProvider}. Valid: ${validProviders.join(', ')}`);
         process.exit(1);
@@ -707,6 +764,19 @@ Examples:
         if (!MINIMAX_MODEL_IDS.includes(model)) {
             console.error(`Unknown model: ${model}. Valid: ${MINIMAX_MODEL_IDS.join(', ')}`);
             process.exit(1);
+        }
+    }
+    if (modelProvider === 'orcarouter') {
+        // `model` defaults to the MiniMax default; if the user did not pass
+        // `--model` explicitly, fall back to the OrcaRouter default instead.
+        if (!ORCAROUTER_MODEL_IDS.includes(model)) {
+            if (model === MINIMAX_DEFAULT_MODEL) {
+                model = ORCAROUTER_DEFAULT_MODEL;
+            }
+            else {
+                console.error(`Unknown model: ${model}. Valid: ${ORCAROUTER_MODEL_IDS.join(', ')}`);
+                process.exit(1);
+            }
         }
     }
     const targetDir = path.resolve(target);

--- a/tools/loop-init/src/cli.ts
+++ b/tools/loop-init/src/cli.ts
@@ -104,10 +104,11 @@ const FOUNDRY_SHOWCASE =
 
 /**
  * Model providers selectable for the implementer preset's `interface` layer.
- * The implementer stack defaults to the existing primitive; `minimax` emits a
- * `model/minimax` provider primitive with regional endpoints and model options.
+ * The implementer stack defaults to the existing primitive; `minimax` and
+ * `orcarouter` emit their own provider primitive with endpoints and model
+ * options instead.
  */
-type ModelProvider = 'anthropic' | 'minimax';
+type ModelProvider = 'anthropic' | 'minimax' | 'orcarouter';
 
 type MiniMaxRegion = 'global_en' | 'cn_zh';
 
@@ -168,6 +169,67 @@ const MINIMAX_REGIONS: MiniMaxRegionEndpoint[] = [
 
 const MINIMAX_MODEL_IDS = MINIMAX_MODELS.map((m) => m.id);
 const MINIMAX_REGION_IDS = MINIMAX_REGIONS.map((r) => r.region);
+
+const ORCAROUTER_DEFAULT_MODEL = 'orcarouter/fusion';
+const ORCAROUTER_BASE_URL = 'https://api.orcarouter.ai';
+
+const ORCAROUTER_MODELS = [
+  {
+    id: 'orcarouter/fusion',
+    contextWindow: 1_000_000,
+    thinking: ['adaptive', 'disabled'],
+    notes: 'Adaptive-routing flagship; multi-model aggregate with automatic failover',
+  },
+  {
+    id: 'orcarouter/fusion-flash',
+    contextWindow: 200_000,
+    thinking: ['adaptive', 'disabled'],
+    notes: 'Fast adaptive-routing tier for high-volume, latency-sensitive loops',
+  },
+  {
+    id: 'orcarouter/auto',
+    contextWindow: 1_000_000,
+    thinking: ['adaptive', 'disabled'],
+    notes: 'Cost-optimized routing tier',
+  },
+  {
+    id: 'orcarouter/free',
+    contextWindow: 200_000,
+    thinking: ['disabled'],
+    notes: 'Zero-cost tier for report-only loops',
+  },
+];
+
+const ORCAROUTER_MODEL_IDS = ORCAROUTER_MODELS.map((m) => m.id);
+
+/**
+ * Render the `model/orcarouter` interface primitive for the implementer stack.
+ * OrcaRouter exposes an OpenAI-compatible gateway that routes a single model
+ * id across many upstream models. Both protocol shapes live on the same
+ * gateway base URL — the OpenAI and Anthropic-compatible paths are identical
+ * and the client picks the wire format via its request headers.
+ */
+function orcarouterInterfaceYaml(model: string): string {
+  const models = ORCAROUTER_MODELS.map((m) =>
+    [
+      `          - id: ${m.id}`,
+      `            context_window: ${m.contextWindow}`,
+      `            thinking: [${m.thinking.join(', ')}]`,
+      `            notes: "${m.notes}"`,
+    ].join('\n'),
+  ).join('\n');
+
+  return `    - primitive: model/orcarouter
+      config:
+        model: ${model}
+        models:
+${models}
+        endpoints:
+          global:
+            openai_base_url: ${ORCAROUTER_BASE_URL}/v1
+            anthropic_base_url: ${ORCAROUTER_BASE_URL}/v1
+            docs_root: https://www.orcarouter.ai`;
+}
 
 /** Render the `model/minimax` interface primitive for the implementer stack. */
 function minimaxInterfaceYaml(model: string, region: MiniMaxRegion): string {
@@ -247,7 +309,9 @@ function foundryStackYaml(
     const interfaceLayer =
       provider === 'minimax'
         ? minimaxInterfaceYaml(model, region)
-        : `    - primitive: model/anthropic
+        : provider === 'orcarouter'
+          ? orcarouterInterfaceYaml(model)
+          : `    - primitive: model/anthropic
       config:
         model: claude-sonnet-4-6`;
     return `name: ${stackName}
@@ -832,9 +896,9 @@ Options:
   --with-foundry    Also scaffold .foundry/ stack (harness-foundry runtime)
   --with-memory     Also scaffold memory-engineering tiers and budget
   --with-fleet      Also scaffold fleet-engineering registry and inbox
-  --model-provider  Implementer interface provider (default: anthropic; minimax)
+  --model-provider  Implementer interface provider (default: anthropic; minimax, orcarouter)
   --region          MiniMax region when --model-provider minimax (global_en, cn_zh)
-  --model           MiniMax model when --model-provider minimax (MiniMax-M3, MiniMax-M2.7)
+  --model           Provider model when --model-provider minimax/orcarouter (default: MiniMax-M3 / orcarouter/fusion)
   --dry-run         Print actions without copying
   -h, --help        This help
 
@@ -849,6 +913,7 @@ Examples:
   npx @cobusgreyling/loop-init . -p pr-babysitter -t claude --with-foundry
   npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax
   npx @cobusgreyling/loop-init . -p ci-sweeper -t grok --with-foundry --model-provider minimax --region cn_zh --model MiniMax-M2.7
+  npx @cobusgreyling/loop-init . -p ci-sweeper -t claude --with-foundry --model-provider orcarouter --model orcarouter/auto
   npx @cobusgreyling/loop-init . -p daily-triage -t opencode
   npx @cobusgreyling/loop-init . --with-memory
   npx @cobusgreyling/loop-init . --with-fleet
@@ -856,7 +921,7 @@ Examples:
     process.exit(0);
   }
 
-  const { pattern, tool, target, dryRun, withFoundry, withMemory, withFleet, modelProvider, region, model } = args;
+  let { pattern, tool, target, dryRun, withFoundry, withMemory, withFleet, modelProvider, region, model } = args;
 
   const validPatterns = Object.keys(PATTERN_STARTERS) as Pattern[];
   const validTools = Object.keys(TOOL_SUFFIX) as Tool[];
@@ -868,7 +933,7 @@ Examples:
     console.error(`Unknown tool: ${tool}. Valid: ${validTools.join(', ')}`);
     process.exit(1);
   }
-  const validProviders: ModelProvider[] = ['anthropic', 'minimax'];
+  const validProviders: ModelProvider[] = ['anthropic', 'minimax', 'orcarouter'];
   if (!validProviders.includes(modelProvider)) {
     console.error(`Unknown model provider: ${modelProvider}. Valid: ${validProviders.join(', ')}`);
     process.exit(1);
@@ -881,6 +946,18 @@ Examples:
     if (!MINIMAX_MODEL_IDS.includes(model)) {
       console.error(`Unknown model: ${model}. Valid: ${MINIMAX_MODEL_IDS.join(', ')}`);
       process.exit(1);
+    }
+  }
+  if (modelProvider === 'orcarouter') {
+    // `model` defaults to the MiniMax default; if the user did not pass
+    // `--model` explicitly, fall back to the OrcaRouter default instead.
+    if (!ORCAROUTER_MODEL_IDS.includes(model)) {
+      if (model === MINIMAX_DEFAULT_MODEL) {
+        model = ORCAROUTER_DEFAULT_MODEL;
+      } else {
+        console.error(`Unknown model: ${model}. Valid: ${ORCAROUTER_MODEL_IDS.join(', ')}`);
+        process.exit(1);
+      }
     }
   }
 

--- a/tools/loop-init/test/cli.test.mjs
+++ b/tools/loop-init/test/cli.test.mjs
@@ -379,6 +379,93 @@ test('loop-init --with-foundry anthropic provider is unchanged (default)', async
   }
 });
 
+test('loop-init --with-foundry --model-provider orcarouter emits OrcaRouter provider primitive', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loop-init-foundry-orcarouter-'));
+  try {
+    const { stdout } = await exec('node', [
+      CLI,
+      dir,
+      '--pattern',
+      'ci-sweeper',
+      '--tool',
+      'grok',
+      '--with-foundry',
+      '--model-provider',
+      'orcarouter',
+    ]);
+    const stack = await readFile(path.join(dir, '.foundry', 'stack.yaml'), 'utf8');
+    assert.match(stack, /primitive: model\/orcarouter/);
+    // default routing model
+    assert.match(stack, /model: orcarouter\/fusion/);
+    // model options table
+    assert.match(stack, /- id: orcarouter\/fusion/);
+    assert.match(stack, /- id: orcarouter\/fusion-flash/);
+    assert.match(stack, /- id: orcarouter\/auto/);
+    assert.match(stack, /- id: orcarouter\/free/);
+    // single global endpoint; both protocol shapes share the gateway base URL
+    assert.match(stack, /https:\/\/api\.orcarouter\.ai\/v1/);
+    assert.match(stack, /anthropic_base_url: https:\/\/api\.orcarouter\.ai\/v1/);
+    assert.doesNotMatch(stack, /model\/anthropic/);
+    assert.doesNotMatch(stack, /model\/minimax/);
+    assert.match(stdout, /preset: implementer/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loop-init --with-foundry orcarouter --model selects a different routing model', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'loop-init-foundry-orcarouter-model-'));
+  try {
+    await exec('node', [
+      CLI,
+      dir,
+      '--pattern',
+      'ci-sweeper',
+      '--tool',
+      'grok',
+      '--with-foundry',
+      '--model-provider',
+      'orcarouter',
+      '--model',
+      'orcarouter/auto',
+    ]);
+    const stack = await readFile(path.join(dir, '.foundry', 'stack.yaml'), 'utf8');
+    assert.match(stack, /model: orcarouter\/auto/);
+    // all routing model options remain available in config
+    assert.match(stack, /- id: orcarouter\/fusion/);
+    assert.match(stack, /- id: orcarouter\/free/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loop-init rejects unknown orcarouter model', async () => {
+  await assert.rejects(
+    () =>
+      exec('node', [
+        CLI,
+        '.',
+        '--pattern',
+        'ci-sweeper',
+        '--tool',
+        'grok',
+        '--with-foundry',
+        '--model-provider',
+        'orcarouter',
+        '--model',
+        'not-a-model',
+        '--dry-run',
+      ]),
+    (err) => err.stderr?.includes('Unknown model') || err.message?.includes('Unknown model'),
+  );
+});
+
+test('loop-init --help documents --model-provider orcarouter', async () => {
+  const { stdout } = await exec('node', [CLI, '--help']);
+  assert.match(stdout, /--model-provider/);
+  assert.match(stdout, /orcarouter/);
+});
+
 test('loop-init rejects unknown model provider', async () => {
   await assert.rejects(
     () =>


### PR DESCRIPTION
## Why

This repo is a pattern library for operating agents around a codebase. When a fix-capable pattern is scaffolded with `--with-foundry`, the implementer stack's `interface` layer defaults to the built-in `model/anthropic` primitive — or, today, a `model/minimax` provider primitive selected via `--model-provider minimax`.

[OrcaRouter](https://www.orcarouter.ai) fits the same slot: an OpenAI-compatible AI gateway that, like OpenRouter, exposes a provider/model namespace across many models — but also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class model provider means this project's users can point an implementer loop at that whole stack directly, without treating OrcaRouter as an anonymous custom base URL.

## Changes

- `tools/loop-init/src/cli.ts` — extend the `ModelProvider` registry (`anthropic | minimax | orcarouter`) and add `orcarouterInterfaceYaml()`, mirroring the existing `minimax` provider wiring: a `model/orcarouter` primitive is emitted into `.foundry/stack.yaml` with the gateway endpoints and routing model options.
- The primitive carries OrcaRouter's OpenAI- and Anthropic-compatible paths on the same base URL (`https://api.orcarouter.ai/v1`) and the routing model options `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/auto`, and `orcarouter/free`.
- `tools/loop-init/test/cli.test.mjs` — 4 new tests: provider primitive emission, `--model` selection, unknown-model rejection, and `--help` docs.
- `tools/loop-init/README.md` + regenerated `tools/loop-init/dist/cli.js` — document the new flag and rebuilt CLI.

## Verification

- `npm test` in `tools/loop-init`: 64/65 pass; the single failure (`loop-init prints Loop Ready score after scaffold`) is pre-existing and unrelated — it needs the local monorepo `@cobusgreyling/readiness-core` install, which is missing in this environment.
- Live-tested the scaffolded config against the gateway: `https://api.orcarouter.ai/v1` returns HTTP 200 for both the OpenAI (`/v1/chat/completions`, model `orcarouter/fusion`) and Anthropic (`/v1/messages` with Anthropic headers) wire formats, and all four routing model ids are present in `/v1/models`.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
