### PR TITLE
Add sofagent to adopters (PR audit gate, L2)

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -39,6 +39,7 @@ Or open a PR that adds a row to the table below:
 | [Hermes Agent](https://github.com/NousResearch/hermes-agent) by [Nous Research](https://nousresearch.com) | Daily Triage | Hermes | L1 | Six loop primitives in one binary — `hermes cron` + skill + `delegate_task` + MCP + memory. Reference: [examples/hermes/daily-triage.md](../examples/hermes/daily-triage.md) |
 | [Pluribus](https://github.com/caioribeiroclw-pixel/pluribus) | Daily Triage, Issue Triage | Mixed (OpenClaw) | L2 | Hourly market/adoption research loop; durable state in control plane; cross-tool privacy-safe receipts needed |
 | [QA API Automation](https://github.com/Ayush02jain/qa-api-automation) | CI Sweeper | GitHub Actions | L1 | Report-only CI failure detection for the API Automation Tests workflow |
+| [sofagent](https://github.com/KongFangXun/sofagent) | PR Audit Gate (dogfood) | GitHub Actions | L2 | 24-rule commit-time audit on every PR (base..head diff, secrets/out-of-scope/blind edits); audit-pass → bot auto-approve, merge stays human |
 
 *Your project here — see [CONTRIBUTING.md](../CONTRIBUTING.md).*
 


### PR DESCRIPTION
Adds one row to [docs/adopters.md](https://github.com/cobusgreyling/loop-engineering/blob/main/docs/adopters.md) — [sofagent](https://github.com/KongFangXun/sofagent), an open-source commit-time audit engine for AI coding agents.

**The loop we run (dogfood, in production on our own repo):**
- **Pattern:** PR Audit Gate — every PR triggers a GitHub Actions workflow that audits the real base..head diff with 24 rules (secret leaks, out-of-scope edits, blind modifications without prior reads, commit-message prompt injection)
- **Maker/checker:** audit exit code maps to three states — pass → bot auto-approves (green light), warn → yellow label, fail → red label + CI blocks
- **Human gate:** merge always stays with the maintainer (HITL)
- **Level: L2, honest** — audit on every PR + tamper-evident HMAC-signed local audit history; not yet full L3 (no scheduled self-audit of the audit)

**Why relevant to loop engineering:** it's the verification leg of the loop for agent-authored code — when Claude Code/Codex/Cursor agents write the PRs, a deterministic audit gate before merge is what keeps the loop trustworthy. MIT, TypeScript.

Single-line change to docs/adopters.md only.