### PR TITLE
examples/mcp: add a shared-state config for the anti-pattern 5 case

### DIFF
--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -2,6 +2,14 @@
 
 <!-- Written by `knos export`. Commit this file. -->
 
+<!--
+Reading this file needs nothing installed: it is plain markdown, and a fresh
+clone picks it up as-is. The live claim/withhold server is a separate, optional
+step - `pip install knos` (Python 3.10+), which the MCP entry launches as
+`python -m knos.mcp`. Without it, everything below still reads normally.
+-->
+
+
 A second clone reads this on its first question — it is one of the decision
 records knos looks for. Nothing here is private: secrets and private paths
 never reach it.

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -1,0 +1,24 @@
+# Decisions and current work
+
+<!-- Written by `knos export`. Commit this file. -->
+
+A second clone reads this on its first question — it is one of the decision
+records knos looks for. Nothing here is private: secrets and private paths
+never reach it.
+
+
+## Decisions
+
+- **shared state without schema** — Three loops appending to one unstructured STATE.md causes state rot, conflicting actions and ghost items. One state file per pattern, or clearly separated sections with prune rules.  _(docs/anti-patterns.md)_
+- **attempt cap** — No loop runs "keep trying until CI is green". Hard cap at three attempts, then escalate with full context in the state file.  _(docs/anti-patterns.md)_
+- **separate verifier** — The agent that implements does not verify its own work. A separate verifier sub-agent or model checks it, and the verifier's default stance is REJECT.  _(docs/anti-patterns.md)_
+- **L1 before L3** — Report-only for the first week. Measure triage accuracy before enabling anything that writes.  _(docs/anti-patterns.md)_
+- **propose, never merge** — Any loop that changes external state opens a draft PR or a comment for a human gate. It never merges.  _(examples/mcp/safe-write-pattern.md)_
+- **minimum privilege** — Loops get the least privilege that works. Prefer read + comment over write; use human gates and worktrees for anything that mutates state.  _(examples/mcp/README.md)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>knos export. Claims lapse after 30 minutes.</sub>

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -41,8 +41,9 @@ See the files in this directory:
 - `github-propose.json` — read + limited write for comments and draft PRs (sign comments as the loop).
 - `linear.json` — example for creating/updating issues from loop state.
 - `slack-read.json` — ingest channel threads into triage.
-- `knos.mcp.json` — local shared state for parallel loops; the record lives in
-  `.knos/decisions.md` in the repo, so a fresh clone reads it with nothing installed.
+- `knos.mcp.json` — local shared state for parallel loops (`pip install knos`,
+  Python 3.10+). The record lives in `.knos/decisions.md` in the repo, so a fresh
+  clone reads it with nothing installed; the server is only needed for live claims.
 - `safe-write-pattern.md` — the recommended architecture for any mutating action.
 
 ## Usage in a Loop Prompt (Grok example)

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -42,8 +42,9 @@ See the files in this directory:
 - `linear.json` — example for creating/updating issues from loop state.
 - `slack-read.json` — ingest channel threads into triage.
 - `knos.mcp.json` — local shared state for parallel loops (`pip install knos`,
-  Python 3.10+). The record lives in `.knos/decisions.md` in the repo, so a fresh
-  clone reads it with nothing installed; the server is only needed for live claims.
+  Python 3.10+). `knos-decisions.example.md` beside it shows the record shape; it
+  is plain markdown, so it reads with nothing installed and the server is only
+  needed for live claims.
 - `safe-write-pattern.md` — the recommended architecture for any mutating action.
 
 ## Usage in a Loop Prompt (Grok example)

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -30,6 +30,7 @@ The local clone/dev path still works if you want to inspect or change the server
 | Linear | Read/update issues from state, create follow-up tickets | API key with project + issue write limited to specific teams | Post-Merge, Dependency Sweeper, CI Sweeper |
 | Slack (read) | Ingest threads / alerts the loop should triage | Read-only on specific channels | Daily Triage |
 | Safe propose flow | Any write action | Loop opens PR / draft / comment. Human merges or approves. | All L2+ patterns |
+| Knos (shared state) | Give parallel loops one state record instead of one STATE.md each | Local only; no network, no account | Anti-pattern 5, PR Babysitter, Daily Triage |
 
 ## Example Configurations
 
@@ -40,6 +41,8 @@ See the files in this directory:
 - `github-propose.json` — read + limited write for comments and draft PRs (sign comments as the loop).
 - `linear.json` — example for creating/updating issues from loop state.
 - `slack-read.json` — ingest channel threads into triage.
+- `knos.mcp.json` — local shared state for parallel loops; the record lives in
+  `.knos/decisions.md` in the repo, so a fresh clone reads it with nothing installed.
 - `safe-write-pattern.md` — the recommended architecture for any mutating action.
 
 ## Usage in a Loop Prompt (Grok example)

--- a/examples/mcp/knos-decisions.example.md
+++ b/examples/mcp/knos-decisions.example.md
@@ -1,6 +1,9 @@
+<!-- Example record shape only. Not this repository's state.
+     `knos export` writes this file; live state stays untracked. -->
+
 # Decisions and current work
 
-<!-- Written by `knos export`. Commit this file. -->
+<!-- Written by `knos export` in an adopting repo. -->
 
 <!--
 Reading this file needs nothing installed: it is plain markdown, and a fresh

--- a/examples/mcp/knos.mcp.json
+++ b/examples/mcp/knos.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "knos": {
+      "command": "knos",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/examples/mcp/knos.mcp.json
+++ b/examples/mcp/knos.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "knos": {
-      "command": "knos",
-      "args": ["mcp"]
+      "command": "python",
+      "args": ["-m", "knos.mcp"]
     }
   }
 }


### PR DESCRIPTION
`docs/anti-patterns.md` #5 — *"Three loops append to one unstructured STATE.md → state rot, conflicting actions, ghost items."* The recommended fix there is one state file per pattern. This adds an example for the other half of that case: when the loops are genuinely working the same surface and need one record rather than separate ones.

**What's in the PR**

- `examples/mcp/knos.mcp.json` — one server, three tools, `stdio`. No ports, no account, no model download.
- `.knos/decisions.md` — the record itself, seeded from this repo's own documented rules (each line cites the file it came from: `anti-patterns.md`, `safe-write-pattern.md`, `examples/mcp/README.md`). Plain markdown, it diffs, and a fresh clone reads it with nothing installed.
- Two lines in `examples/mcp/README.md` — one Quick Patterns row, one entry in Example Configurations, matching the existing format.

**Why the record is in the repo rather than a database**

It follows `safe-write-pattern.md` step 6, "record in state". The file is the whole interface — no server to run, no protocol to adopt. A loop that has no idea what Knos is still gets the context, because the file is already in the checkout.

**Disclosure:** I wrote Knos. I've kept this to the documented contribution path for a tool example and seeded the record from your docs rather than mine, so it's inspectable rather than promotional. If a third-party tool example isn't wanted here, close it — no hard feelings, and the anti-pattern write-up stands on its own either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)